### PR TITLE
Documentation improvements

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -138,7 +138,7 @@ TBot.  There are a lot more, for different tasks.  Take a look at the :ref:`reci
         import tbot
 
         @tbot.testcase
-        def my_testcase(lab = None) -> None:
+        def my_testcase(lab = None):
             with lab or tbot.acquire_lab() as lh:
                 name = lh.exec0("uname", "-n")
                 tbot.log.message(f"Hello {name}!")

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,6 +1,6 @@
 Installation
 ============
-Clone `TBot's repository <https://gitlab.denx.de/HaraldSeiler/tbot>`_, then
+Clone `TBot's repository <https://github.com/Rahix/tbot>`_, then
 install TBot using
 
 ::


### PR DESCRIPTION
Two minor documentation changes:

* There is a small example that shows how tests can be written without type annotations but it still contains a return type annotation which is not really required so I removed that as well.

* The other change is to use the public Github URL in the documentation instead of gitlab.denx.com which seems to require registration.

