### PR TITLE
Fix call to lab enable() method

### DIFF
--- a/tbot/machine/linux/build.py
+++ b/tbot/machine/linux/build.py
@@ -140,5 +140,5 @@ class Builder(linux_shell.LinuxShell):
         tc = self.toolchains[arch]
 
         with self.subshell():
-            tc.enable(self)
+            tc.enable(tc, self)
             yield None


### PR DESCRIPTION
This needs to pass both self and the host. Fix it.

Signed-off-by: Simon Glass <sjg@chromium.org>