### PR TITLE
Introduce "Context" mechanism for machine instance management

### DIFF
--- a/Documentation/configuration.rst
+++ b/Documentation/configuration.rst
@@ -107,6 +107,8 @@ defines the software running on it.
    file.  We plan to (optionally) separate this in the future to allow even
    more generic configurations.
 
+.. _config-board-hardware:
+
 Board-Hardware Config
 ~~~~~~~~~~~~~~~~~~~~~
 The hardware is configured as a machine which turns on the board when accessed
@@ -209,6 +211,8 @@ In testcases, you can now access U-Boot by first acquiring the hardware using
        with tbot.acquire_board(lh) as b:
            with tbot.acquire_uboot(b) as ub:
                ub.exec0("version")
+
+.. _config-board-linux-uboot:
 
 Linux (from U-Boot) Config
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/context.rst
+++ b/Documentation/context.rst
@@ -99,6 +99,28 @@ registered in the context.  The best way to do this is this:
    Eventually, tbot might grow a new decorator for making contex usage even
    easier.  For now the above patterns are what should be used.
 
+Complex Testcases (e.g. Powercycle)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Sometimes, testcases need to do more complex things with instances than to
+simply interact with them.  A common example would be a powercycle of a DUT.
+For such cases, the :py:meth:`Context.request() <tbot.Context.request>` method
+provides some keyword arguments to allow fine-grained control over instance
+requesting.
+
+For the DUT powercycle example, a testcase might look like this:
+
+.. code-block:: python
+
+   @tbot.testcase
+   def test_with_dut_reboot():
+       with tbot.ctx.request(tbot.role.BoardLinux) as lnx:
+           # Do some things before powercycle
+           lnx.exec0("hwclock", "--systohc")
+
+       with tbot.ctx.request(tbot.role.BoardLinux, reset=True) as lnx:
+           # The DUT was powercycled before entering this context
+           lnx.exec0("hwclock", "--hctosys")
+
 .. _tbot_role:
 
 Roles

--- a/Documentation/context.rst
+++ b/Documentation/context.rst
@@ -1,0 +1,196 @@
+.. _context:
+
+Context
+=======
+The *context* is the new mechanism in tbot for managing machine instances.
+Under the hood, the old configuration mechanism and the
+:py:mod:`tbot.selectable` module are already using the context but using it
+directly gives you even more power!
+
+The idea
+--------
+At the core, everything revolves around a context object:
+
+ - Configuration registers machines with the context object (See
+   :ref:`tbot_ctx_config`).
+ - Testcases can then request instances of registered machines (See
+   :ref:`tbot_ctx`).
+
+Machines are registered for fulfilling certain :ref:`roles <tbot_role>`.  For
+example the lab-config should register a machine for the
+:py:class:`tbot.role.LabHost` role while the board-config registers machines for
+e.g.  :py:class:`tbot.role.Board` and :py:class:`tbot.role.BoardLinux`.
+
+When a testcase requests a machine, the instance that is created is *cached*.
+That means when a later testcase requests the same machine (before the first one
+released it again!), it will get access to the *same* instance.
+
+.. _tbot_ctx:
+
+The ``tbot.ctx`` object
+-----------------------
+tbot defines a global context as ``tbot.ctx``.  Testcases can directly interact
+with this context to access machines.  See the :py:class:`tbot.Context` class
+for the full API.  Essentially, there are two design patterns for testcases:
+
+Single Machine
+^^^^^^^^^^^^^^
+.. code-block:: python
+
+   @tbot.testcase
+   def test_with_labhost():
+       with tbot.ctx.request(tbot.role.LabHost) as lh:
+           lh.exec0("uname", "-a")
+
+Multiple Machines
+^^^^^^^^^^^^^^^^^
+This is analogous to pythons own :py:class:`contextlib.ExitStack` and useful
+when you need multiple machines (= multiple context-managers) in one testcase:
+
+.. code-block:: python
+
+   @tbot.testcase
+   def test_with_board_and_lab():
+      with tbot.ctx() as cx:
+         lh = cx.request(tbot.role.LabHost)
+         lnx = cx.request(tbot.role.BoardLinux)
+
+         lh.exec0("hostname")
+         lnx.exec0("hostname")
+
+Keeping tests flexible
+^^^^^^^^^^^^^^^^^^^^^^
+When writing reusable testcases, you should always prepare them for situations
+where a caller would want to pass in custom machines instead of the ones
+registered in the context.  The best way to do this is this:
+
+.. code-block:: python
+
+   @tbot.testcase
+   def reusable_test_one_machine(m: Optional[LinuxShell] = None):
+       with tbot.ctx() as cx:
+           if m is None:
+               m = cx.request(tbot.role.LabHost)
+
+           ...
+
+   @tbot.testcase
+   def reusable_test_multiple(
+       lab: Optional[LinuxShell] = None,
+       ub: Optional[UBootShell] = None,
+   ):
+       with tbot.ctx() as cx:
+           if lab is None:
+               lab = cx.request(tbot.role.LabHost)
+           if ub is None:
+               ub = cx.request(tbot.role.BoardUBoot)
+
+           ...
+
+.. todo::
+
+   Eventually, tbot might grow a new decorator for making contex usage even
+   easier.  For now the above patterns are what should be used.
+
+.. _tbot_role:
+
+Roles
+-----
+The :py:mod:`tbot.role` module pre-defines a number of roles that are commonly
+needed in embedded automation and testing.  These roles are also what testcases
+distributed alongside tbot use.  As an overview (details are in the
+:py:mod:`tbot.role` module documentation):
+
+ - :py:class:`tbot.role.LabHost`
+ - :py:class:`tbot.role.BuildHost`
+ - :py:class:`tbot.role.LocalHost`
+ - :py:class:`tbot.role.Board`
+ - :py:class:`tbot.role.BoardUBoot`
+ - :py:class:`tbot.role.BoardLinux`
+
+However, you can also define your own roles for more complex scenarios!  The
+role should inherit :py:class:`tbot.role.Role` and any ABCs that a machine-class
+implementing the role uses.  For example, a role for a Linux machine should
+probably inherit :py:class:`tbot.machine.linux.LinuxShell`.  Or a role for
+a U-Boot machine should inherit :py:class:`tbot.machine.board.UBootShell`.
+
+.. _tbot_ctx_config:
+
+Configuration
+-------------
+For :py:mod:`tbot.selectable`, machines were configured via globals in the lab-
+and board-config named ``LAB``, ``BOARD``, ``UBOOT``, and ``LINUX``.  This still
+works and will actually register the machines in :py:data:`tbot.ctx` under the
+hood.
+
+The new context-based configuration works slightly different:  lab- and
+board-config scripts should define a global ``register_machines()`` function
+that registers all machines from this config into the supplied context using
+:py:meth:`tbot.Context.register`.  The method documentation explains the details
+of registration but here are two examples:
+
+Example lab-config
+^^^^^^^^^^^^^^^^^^
+.. code-block:: python
+
+   class MyLab(...):
+       ...
+
+   class MyBuildHost(...):
+       ...
+
+   def register_machines(ctx: tbot.Context) -> None:
+       ctx.register(MyLab, tbot.role.LabHost)
+       # Optionally register a build-host as well
+       ctx.register(MyBuildHost, tbot.role.BuildHost)
+
+       # You could also register MyLab for both LabHost and BuildHost:
+       ctx.register(MyLab, [tbot.role.LabHost, tbot.role.BuildHost])
+
+Example board-config
+^^^^^^^^^^^^^^^^^^^^
+.. code-block:: python
+
+   class MyBoard(...):
+       ...
+
+   class MyBoardLinux(...):
+       ...
+
+   def register_machines(ctx: tbot.Context) -> None:
+       ctx.register(MyBoard, tbot.role.Board)
+       ctx.register(MyBoardLinux, tbot.role.BoardLinux)
+
+Controlling machine instanciation
+---------------------------------
+When a testcase calls :py:meth:`tbot.Context.request` to request a machine
+instance, this instance needs to be created which is not trivial in all cases.
+The context relies on the :py:meth:`Connector.from_context()
+<tbot.machine.connector.Connector.from_context>` classmethod of the registered
+machine-class for this.
+
+Most connectors come with a reasonable default implementation of this method
+which often just requests the prerequisite machines from the context and then
+constructs the machine-class using them.  As an example, here is the
+implementation of ``from_context()`` for
+:py:class:`~tbot.machine.connector.ConsoleConnector`:
+
+.. code-block:: python
+
+    @classmethod
+    @contextlib.contextmanager
+    def from_context(cls, ctx: "tbot.Context"):
+        with contextlib.ExitStack() as cx:
+            # Will try to connect to console from lab-host, thus request
+            # lab-host here:
+            lh = cx.enter_context(ctx.request(tbot.role.LabHost))
+
+            # Then instanciate the machine-class using `lh`:
+            m = cx.enter_context(cls(lh))
+            yield m
+
+For more complex scenarios, lab- or board-config can of course overwrite this
+method with custom behavior.  Please keep in mind the special semantics of
+:py:meth:`Connector.from_context()
+<tbot.machine.connector.Connector.from_context>` which are detailed in the
+method documentation.

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -13,6 +13,7 @@ started with our :ref:`quickstart` guide!
    configuration
    recipes
    logging
+   context
    migration
 
 .. toctree::
@@ -27,6 +28,7 @@ started with our :ref:`quickstart` guide!
    modules/machine_connector
    modules/machine_shell
    modules/machine_channel
+   modules/role
    modules/selectable
 
 .. toctree::

--- a/Documentation/modules/main.rst
+++ b/Documentation/modules/main.rst
@@ -12,6 +12,46 @@ The testcase decorators will also track time and success of each run.
 .. autofunction:: tbot.testcase
 .. autofunction:: tbot.named_testcase
 
+Context
+-------
+The new mechanism for machine management is the :ref:`context <context>`
+(superseding :py:mod:`tbot.selectable`).  The global context is stored in
+:py:data:`tbot.ctx` which is an instance of :py:class:`tbot.Context`.  Read the
+:ref:`context` guide for a detailed introduction.
+
+.. py:data:: tbot.ctx
+   :type: tbot.Context
+
+   The global context.  This context should be used in testcases for accessing
+   machines via the following pattern:
+
+   **Single Machine**:
+
+   .. code-block:: python
+
+      @tbot.testcase
+      def test_with_labhost():
+          with tbot.ctx.request(tbot.role.LabHost) as lh:
+              lh.exec0("uname", "-a")
+
+   **Multiple Machines**:
+
+   .. code-block:: python
+
+      @tbot.testcase
+      def test_with_board_and_lab():
+         with tbot.ctx() as cx:
+            lh = cx.request(tbot.role.LabHost)
+            lnx = cx.request(tbot.role.BoardLinux)
+
+            lh.exec0("hostname")
+            lnx.exec0("hostname")
+
+   See the :py:class:`tbot.Context` class below for the API details.
+
+.. autoclass:: tbot.Context
+   :members:
+
 Convenience Decorators
 ----------------------
 To make writing testcase interacting with machines easier, tbot provides three

--- a/Documentation/modules/role.rst
+++ b/Documentation/modules/role.rst
@@ -1,0 +1,28 @@
+.. py:module:: tbot.role
+
+``tbot.role``
+=============
+Machine-roles as introduced in :ref:`tbot_role`.
+
+.. autoclass:: tbot.role.Role
+
+Predefined Roles
+----------------
+Here's a diagram with a rough outline of what each role is for.  Note that this
+is entirely flexible though: E.g. you can use your localhost (= tbot-host) as
+lab-host or have build-host and lab-host be the same machine just as well!
+
+.. only:: html
+
+   .. image:: ../static/tbot.svg
+
+.. only:: latex
+
+   .. image:: ../static/tbot.png
+
+.. autoclass:: tbot.role.LabHost
+.. autoclass:: tbot.role.BuildHost
+.. autoclass:: tbot.role.LocalHost
+.. autoclass:: tbot.role.Board
+.. autoclass:: tbot.role.BoardUBoot
+.. autoclass:: tbot.role.BoardLinux

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -251,6 +251,8 @@ a testcase that returns normally passes and one that raises an ``Exception`` has
 pretty convenient:  You can easily catch failures by using a try-block and your testcases will also
 automatically fail if anything unexpected happens.
 
+.. _quickstart_machines:
+
 Machines
 --------
 Next up: Machines!  Machines are what tbot is made for.  Let's take a look at the diagram from the

--- a/tbot/__init__.py
+++ b/tbot/__init__.py
@@ -34,6 +34,7 @@ from .decorators import (
     with_uboot,
     with_linux,
 )
+from .context import Context
 
 __all__ = (
     "selectable",
@@ -49,6 +50,8 @@ __all__ = (
     "with_lab",
     "with_uboot",
     "with_linux",
+    "ctx",
+    "Context",
 )
 
 flags: typing.Set[str] = set()
@@ -160,3 +163,6 @@ def Re(pat: typing.Union[str, bytes], flags: int = 0) -> typing.Pattern[bytes]:
     """
     pat_bytes = pat if isinstance(pat, bytes) else pat.encode("utf-8")
     return __import__("re").compile(pat_bytes, flags)  # type: ignore
+
+
+ctx = Context(add_defaults=True)

--- a/tbot/__init__.py
+++ b/tbot/__init__.py
@@ -20,6 +20,7 @@ import typing
 from tbot import log, log_event
 
 from . import selectable
+from . import role
 from .selectable import (
     acquire_lab,
     acquire_board,
@@ -52,6 +53,7 @@ __all__ = (
     "with_linux",
     "ctx",
     "Context",
+    "role",
 )
 
 flags: typing.Set[str] = set()

--- a/tbot/context.py
+++ b/tbot/context.py
@@ -280,6 +280,13 @@ class Context(typing.ContextManager):
             assert isinstance(m, machine_class), f"machine type mismatch"
             yield m
 
+    def get_machine_class(self, type: Callable[..., M]) -> Type[M]:
+        """
+        Return the registered machine class for a :py:class:`~tbot.role.Role`.
+        """
+        type = typing.cast(Type[M], type)
+        return typing.cast(Type[M], self._roles[type])
+
     @contextlib.contextmanager
     def __call__(self) -> "Iterator[ContextHandle]":
         with contextlib.ExitStack() as exitstack:
@@ -310,3 +317,6 @@ class ContextHandle:
         return self._exitstack.enter_context(
             self.ctx.request(type, reset=reset, exclusive=exclusive)
         )
+
+    def get_machine_class(self, type: Callable[..., M]) -> Type[M]:
+        return self.ctx.get_machine_class(type)

--- a/tbot/context.py
+++ b/tbot/context.py
@@ -306,6 +306,9 @@ class Context(typing.ContextManager):
                     tbot.log.warning(f"Found dangling {ty!r} instance in this context")
 
 
+T = TypeVar("T")
+
+
 class ContextHandle:
     def __init__(self, ctx: Context, exitstack: contextlib.ExitStack) -> None:
         self.ctx = ctx
@@ -314,9 +317,12 @@ class ContextHandle:
     def request(
         self, type: Callable[..., M], *, reset: bool = False, exclusive: bool = False
     ) -> M:
-        return self._exitstack.enter_context(
+        return self.enter_context(
             self.ctx.request(type, reset=reset, exclusive=exclusive)
         )
 
     def get_machine_class(self, type: Callable[..., M]) -> Type[M]:
         return self.ctx.get_machine_class(type)
+
+    def enter_context(self, context: ContextManager[T]) -> T:
+        return self._exitstack.enter_context(context)

--- a/tbot/context.py
+++ b/tbot/context.py
@@ -1,0 +1,176 @@
+import contextlib
+import typing
+from typing import Any, Callable, Dict, Iterator, List, Set, Type, TypeVar, Union
+
+import tbot
+import tbot.error
+import tbot.role
+from tbot import machine
+
+M = TypeVar("M", bound=machine.Machine)
+
+
+class Context(typing.ContextManager):
+    """
+    A context which machines can be registered in and where instances can be retrieved from.
+
+    You will usually access the global context :py:data:`tbot.ctx` which is an
+    instance of this class instead of instanciating :py:class:`tbot.Context`
+    yourself.  See the :ref:`context` guide for a detailed introduction.
+    """
+
+    def __init__(self, *, add_defaults: bool = False) -> None:
+        self._roles: Dict[Type[tbot.role.Role], Type[machine.Machine]] = {}
+        self._weak_roles: Set[Type[tbot.role.Role]] = set()
+        self._instances: Dict[Type[machine.Machine], machine.Machine] = {}
+        self._open_contexts = 0
+
+        if add_defaults:
+            tbot.role._register_default_machines(self)
+
+    def register(
+        self, machine: Type[M], roles: Union[Any, List[Any]], *, weak: bool = False
+    ) -> None:
+        """
+        Register a machine in this context for certain roles.
+
+        Registers the machine-class ``machine`` for the role ``roles`` or, if
+        ``roles`` is a list, for all roles it contains.  If for any role
+        a machine is already registered, an exception is thrown.
+
+        This function is usually called in the ``register_machines()`` function
+        of a lab- or board-config:
+
+        .. code-block:: python
+
+            class SomeLabHostClass(...):
+                ...
+
+            def register_machines(ctx: tbot.Context) -> None:
+                ctx.register(SomeLabHostClass, tbot.role.LabHost)
+
+                # or, to register for multiple roles
+                ctx.register(SomeLabHostClass, [tbot.role.LabHost, tbot.role.BuildHost])
+
+        :param machine: A concrete machine-class to be registered.  This
+            machine-class will later be instanciated on request via its
+            :py:meth:`Connector.from_context()
+            <tbot.machine.connector.Connector.from_context()>` classmethod.
+        :param roles: Either a single role or a list of roles for which
+            ``machine`` should be registered.
+        :param bool weak: Changes the way registration works:  The machine is
+            only registered for those roles which do not already have a machine
+            registered.  It will be registered as a weak default which means
+            a later register will overwrite it without erroring.  This is
+            usually not necessary and should be used with care.
+        """
+        if not isinstance(roles, list):
+            roles = [roles]
+
+        for role in roles:
+            if not issubclass(role, tbot.role.Role):
+                tbot.error.TbotException(f"{role!r} is not a role")
+
+            if role in self._roles:
+                if weak:
+                    continue
+                elif role in self._weak_roles:
+                    # Overwrite the weak default
+                    self._weak_roles.discard(role)
+                else:
+                    raise KeyError(
+                        f"a machine is already registered for role {tbot.role.rolename(role)}"
+                    )
+
+            if weak:
+                self._weak_roles.add(role)
+            self._roles[role] = machine
+
+    @contextlib.contextmanager
+    def request(self, type: Callable[..., M]) -> Iterator[M]:
+        """
+        Request a machine instance from this context.
+
+        Requests an instance of the :ref:`role <tbot_role>` ``type`` from the context.  If no
+        instance exists, one will be created.  If a previous testcase has
+        already requested such an instance, the same instance is returned.
+
+        This function must be used as a context manager:
+
+        .. code-block:: python
+
+            @tbot.testcase
+            def foo_bar():
+                with tbot.ctx.request(tbot.role.LabHost) as lh:
+                    lh.exec0("uname", "-a")
+
+        Alternatively, if you need multiple machines, a pattern similar to
+        :py:class:`contextlib.ExitStack` can be used:
+
+        .. code-block:: python
+
+            @tbot.testcase
+            def foo_bar():
+                with tbot.ctx() as cx:
+                    lh = cx.request(tbot.role.LabHost)
+                    bh = cx.request(tbot.role.BuildHost)
+
+                    lh.exec0("cat", "/etc/os-release")
+                    bh.exec0("free", "-h")
+
+        :param type: The :ref:`role <tbot_role>` for which a machine instance
+            is requested.
+        """
+        type = typing.cast(Type[M], type)
+
+        m = None
+
+        try:
+            with contextlib.ExitStack() as cx:
+                if type not in self._roles and type in self._instances:
+                    m = cx.enter_context(self._instances[type])
+                elif type in self._roles:
+                    machine_class = self._roles[type]
+
+                    if machine_class in self._instances:
+                        m = cx.enter_context(self._instances[machine_class])
+                    else:
+                        m = cx.enter_context(machine_class.from_context(self))
+                        assert isinstance(m, machine_class), f"machine type mismatch"
+                        self._instances[machine_class] = m
+                else:
+                    raise IndexError(f"no machine found for {type!r}")
+
+                yield typing.cast(M, m)
+        finally:
+            # After exiting the context, check if this machine has a refcount
+            # of 0.  This would mean it was deinitialized and we should discard
+            # it now.
+            if m is not None and m._rc == 0:
+                del self._instances[machine_class]
+
+    @contextlib.contextmanager
+    def __call__(self) -> "Iterator[ContextHandle]":
+        with contextlib.ExitStack() as exitstack:
+            handle = ContextHandle(self, exitstack)
+            yield handle
+
+    def __enter__(self) -> "Context":
+        self._open_contexts += 1
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self._open_contexts -= 1
+
+        if self._open_contexts == 0:
+            for inst in self._instances:
+                tbot.log.warning("Found a dangling {inst!r} in this context")
+
+
+class ContextHandle:
+    def __init__(self, ctx: Context, exitstack: contextlib.ExitStack) -> None:
+        self.ctx = ctx
+        self._exitstack = exitstack
+
+    def request(self, type: Callable[..., M]) -> M:
+        return self._exitstack.enter_context(self.ctx.request(type))

--- a/tbot/machine/board/board.py
+++ b/tbot/machine/board/board.py
@@ -115,7 +115,7 @@ class Connector(connector.Connector):
     @contextlib.contextmanager
     def from_context(cls: typing.Type[M], ctx: "tbot.Context") -> typing.Iterator[M]:
         with contextlib.ExitStack() as cx:
-            b = cx.enter_context(ctx.request(tbot.role.Board))
+            b = cx.enter_context(ctx.request(tbot.role.Board, exclusive=True))
             m = cx.enter_context(cls(b))  # type: ignore
             yield m
 

--- a/tbot/machine/board/board.py
+++ b/tbot/machine/board/board.py
@@ -99,6 +99,9 @@ class Board(shell.RawShell):
     pass
 
 
+M = typing.TypeVar("M", bound=machine.Machine)
+
+
 class Connector(connector.Connector):
     def __init__(self, board: typing.Union[Board, channel.Channel]) -> None:
         if not (isinstance(board, Board) or isinstance(board, channel.Channel)):
@@ -107,6 +110,14 @@ class Connector(connector.Connector):
             )
         self._board = board
         self.host = getattr(board, "host", None)
+
+    @classmethod
+    @contextlib.contextmanager
+    def from_context(cls: typing.Type[M], ctx: "tbot.Context") -> typing.Iterator[M]:
+        with contextlib.ExitStack() as cx:
+            b = cx.enter_context(ctx.request(tbot.role.Board))
+            m = cx.enter_context(cls(b))  # type: ignore
+            yield m
 
     @contextlib.contextmanager
     def _connect(self) -> typing.Iterator[channel.Channel]:

--- a/tbot/machine/board/linux.py
+++ b/tbot/machine/board/linux.py
@@ -185,6 +185,16 @@ class LinuxUbootConnector(connector.Connector, LinuxBootLogin):
     def __init__(self, b: typing.Union[board.Board, board.UBootShell]) -> None:
         self._b = b
 
+    @classmethod
+    @contextlib.contextmanager
+    def from_context(
+        cls: typing.Type[Self], ctx: "tbot.Context"
+    ) -> typing.Iterator[Self]:
+        with contextlib.ExitStack() as cx:
+            ub = cx.enter_context(ctx.request(tbot.role.BoardUBoot))
+            m = cx.enter_context(cls(ub))  # type: ignore
+            yield m
+
     @contextlib.contextmanager
     def _connect(self) -> typing.Iterator[channel.Channel]:
         with contextlib.ExitStack() as cx:

--- a/tbot/machine/board/linux.py
+++ b/tbot/machine/board/linux.py
@@ -191,7 +191,7 @@ class LinuxUbootConnector(connector.Connector, LinuxBootLogin):
         cls: typing.Type[Self], ctx: "tbot.Context"
     ) -> typing.Iterator[Self]:
         with contextlib.ExitStack() as cx:
-            ub = cx.enter_context(ctx.request(tbot.role.BoardUBoot))
+            ub = cx.enter_context(ctx.request(tbot.role.BoardUBoot, exclusive=True))
             m = cx.enter_context(cls(ub))  # type: ignore
             yield m
 

--- a/tbot/machine/connector/common.py
+++ b/tbot/machine/connector/common.py
@@ -19,10 +19,11 @@ import contextlib
 import typing
 
 import tbot.error
+from tbot import machine  # noqa: F401
 from .. import channel, linux
 from . import connector
 
-SelfSubprocess = typing.TypeVar("SelfSubprocess", bound="SubprocessConnector")
+M = typing.TypeVar("M", bound="machine.Machine")
 
 
 class SubprocessConnector(connector.Connector):
@@ -53,14 +54,11 @@ class SubprocessConnector(connector.Connector):
     def _connect(self) -> channel.Channel:
         return channel.SubprocessChannel()
 
-    def clone(self: SelfSubprocess) -> SelfSubprocess:
+    def clone(self: M) -> M:
         """Clone this machine."""
         new = type(self)()
         new._orig = self._orig or self
         return new
-
-
-SelfConsole = typing.TypeVar("SelfConsole", bound="ConsoleConnector")
 
 
 class ConsoleConnector(connector.Connector):
@@ -121,6 +119,6 @@ class ConsoleConnector(connector.Connector):
             yield ch
             # yield cloned.open_channel("picocom", "-b", str(115200), "/dev/ttyUSB0")
 
-    def clone(self: SelfConsole) -> SelfConsole:
+    def clone(self: M) -> M:
         """This machine is **not** cloneable."""
         raise NotImplementedError("can't clone a serial connection")

--- a/tbot/machine/connector/connector.py
+++ b/tbot/machine/connector/connector.py
@@ -16,6 +16,8 @@
 
 import abc
 import typing
+
+import tbot
 import tbot.error
 from .. import channel, machine
 
@@ -59,6 +61,36 @@ class Connector(machine.Machine):
                         ...
         """
         raise tbot.error.AbstractMethodError()
+
+    @classmethod
+    def from_context(
+        cls: typing.Type[Self], ctx: "tbot.Context"
+    ) -> typing.ContextManager[Self]:
+        """
+        Create this machine from a tbot context.
+
+        This method defines how tbot can automatically attempt creating this
+        machine from a given context.  It is usually defined by the connector
+        but might be overridden by board config in certain more complex
+        scenarios.
+
+        This method must return a context-manager that, upen entering, yields a
+        **fully initialized** machine.  In practical terms this means, the
+        implementation must enter the "machine's context" as well.  As an
+        example, the most basic implementation would look like this:
+
+        .. code-block:: python
+
+            @contextlib.contextmanager
+            def from_context(cls, ctx):
+                # Create instance and enter its context, in this example, no
+                # args are passed to the constructor ...
+                with cls() as m:
+                    yield m
+        """
+        raise NotImplementedError(
+            f"connector of {cls!r} does not (yet) implement from_context()"
+        )
 
     @abc.abstractmethod
     def clone(self: Self) -> Self:

--- a/tbot/machine/connector/paramiko.py
+++ b/tbot/machine/connector/paramiko.py
@@ -19,6 +19,7 @@ import getpass
 import paramiko
 import pathlib
 import typing
+import contextlib
 
 import tbot
 from .. import channel
@@ -141,6 +142,14 @@ class ParamikoConnector(connector.Connector):
         if other is not None:
             self._client = other._client
             self._config = other._config
+
+    @classmethod
+    @contextlib.contextmanager
+    def from_context(
+        cls: typing.Type[Self], ctx: "tbot.Context"
+    ) -> typing.Iterator[Self]:
+        with cls() as m:
+            yield m
 
     def _connect(self) -> channel.Channel:
         if self._client is None:

--- a/tbot/machine/connector/ssh.py
+++ b/tbot/machine/connector/ssh.py
@@ -23,6 +23,8 @@ from . import connector
 from .. import linux, channel
 from ..linux import auth
 
+Self = typing.TypeVar("Self", bound="SSHConnector")
+
 
 class SSHConnector(connector.Connector):
     """
@@ -147,6 +149,16 @@ class SSHConnector(connector.Connector):
             self.host = host
         else:
             self.host = tbot.acquire_local()  # type: ignore
+
+    @classmethod
+    @contextlib.contextmanager
+    def from_context(
+        cls: typing.Type[Self], ctx: "tbot.Context"
+    ) -> typing.Iterator[Self]:
+        with contextlib.ExitStack() as cx:
+            lh = cx.enter_context(ctx.request(tbot.role.LabHost))
+            m = cx.enter_context(cls(lh))  # type: ignore
+            yield m
 
     @contextlib.contextmanager
     def _connect(self) -> typing.Iterator[channel.Channel]:

--- a/tbot/machine/machine.py
+++ b/tbot/machine/machine.py
@@ -69,6 +69,13 @@ class Machine(abc.ABC):
     def _connect(self) -> typing.ContextManager[channel.Channel]:
         raise tbot.error.AbstractMethodError()
 
+    @classmethod
+    @abc.abstractmethod
+    def from_context(
+        cls: typing.Type[Self], ctx: "tbot.Context"
+    ) -> typing.ContextManager[Self]:
+        raise tbot.error.AbstractMethodError()
+
     @abc.abstractmethod
     def clone(self: Self) -> Self:
         raise tbot.error.AbstractMethodError()

--- a/tbot/main.py
+++ b/tbot/main.py
@@ -317,31 +317,32 @@ def main() -> None:  # noqa: C901
         )
 
     try:
-        for tc in args.testcase:
-            func = testcases[tc]
+        with tbot.ctx:
+            for tc in args.testcase:
+                func = testcases[tc]
 
-            if len(args.testcase) == 1:
-                params = parameters
-            else:
-                # Filter parameter list if multiple testcases are scheduled to run
+                if len(args.testcase) == 1:
+                    params = parameters
+                else:
+                    # Filter parameter list if multiple testcases are scheduled to run
 
-                try:
-                    func_code = getattr(func, "__wrapped__").__code__
-                except AttributeError:
-                    func_code = func.__code__
-                # Get list of argument names
-                argspec = inspect.getargs(func_code)
+                    try:
+                        func_code = getattr(func, "__wrapped__").__code__
+                    except AttributeError:
+                        func_code = func.__code__
+                    # Get list of argument names
+                    argspec = inspect.getargs(func_code)
 
-                params = {}
-                for name, value in parameters.items():
-                    if argspec.varkw is not None or name in argspec.args:
-                        params[name] = value
-                    else:
-                        tbot.log.warning(
-                            f"Parameter {name!r} not defined for testcase {tc!r}, ignoring ..."
-                        )
+                    params = {}
+                    for name, value in parameters.items():
+                        if argspec.varkw is not None or name in argspec.args:
+                            params[name] = value
+                        else:
+                            tbot.log.warning(
+                                f"Parameter {name!r} not defined for testcase {tc!r}, ignoring ..."
+                            )
 
-            func(**params)
+                func(**params)
     except Exception as e:  # noqa: E722
         import traceback
 

--- a/tbot/role.py
+++ b/tbot/role.py
@@ -1,0 +1,156 @@
+import contextlib
+import types
+from typing import Any, Iterator
+
+import tbot
+from tbot.machine import board, linux
+
+
+class Role:
+    """
+    Base class for all roles.
+
+    See :ref:`tbot_role` for details.
+    """
+
+    pass
+
+
+class LabHost(linux.Lab, Role):
+    """
+    Role for the "lab-host".
+
+    As shown on the diagram above, the lab-host is the
+    central host from where connections to other machines are made.  This can
+    be your localhost in simple cases or any ssh-reachable machine if working
+    remotely.
+
+    A machine for this role should be registered by the lab-config.  If this is
+    not done, it defaults to a localhost lab-host machine.
+
+    Testcases should use the lab-host for any "host" operations if that is at
+    all possible.
+    """
+
+    pass
+
+
+class BuildHost(linux.Builder, Role):
+    """
+    Role for the "build-host".
+
+    The build-host is an optional machine for building/compiling software.  In
+    simple cases, this can just be the lab-host but when builds are more
+    complex, it can be beneficial to use an external build-server with more
+    CPU-power for this.
+
+    Generic testcases for building e.g. U-Boot or Linux should use this machine.
+    """
+
+    pass
+
+
+class LocalHost(linux.LinuxShell, Role):
+    """
+    Role for the localhost or "tbot-host", the machine tbot is running on.
+
+    When using a remote lab-host, sometimes on wants to e.g. download an
+    artifact from the lab-host to the localhost or upload a local file to the
+    lab-host.  This machine can be referenced for such purposes.
+
+    In most circumstances, it should not be necessary to register a custom
+    machine for this role.  It might however be useful for situations where you
+    want to e.g. modify the ``workdir()`` on localhost.
+    """
+
+    pass
+
+
+class Board(board.Board, Role):
+    """
+    Role for the DUT (device under test, "the board") hardware.
+
+    As described in :ref:`config-board`, in tbot, the board is represented by
+    one machine for the "physical device" and separate machines for the
+    software running on it.  This role defines the physical hardware and e.g.
+    manages turning on and off board power.
+
+    See :ref:`config-board-hardware` for more.
+    """
+
+    pass
+
+
+class BoardUBoot(board.UBootShell, Role):
+    """
+    Role for a U-Boot bootloader machine running on the :py:class:`tbot.role.Board`.
+
+    See :ref:`config-board-uboot` for details how such a machine should be configured.
+    """
+
+    pass
+
+
+class BoardLinux(linux.LinuxShell, Role):
+    """
+    Role for a Linux OS running on the :py:class:`tbot.role.Board`.
+
+    There's multiple ways to configure such a machine.  See
+    :ref:`config-board-linux-standalone` or :ref:`config-board-linux-uboot`,
+    depending on what you need.
+    """
+
+    pass
+
+
+def isrole(cls: Any) -> bool:
+    try:
+        return Role in getattr(cls, "__bases__")
+    except AttributeError:
+        raise ValueError("{cls!r} is not a class") from None
+
+
+def rolename(cls: Any) -> str:
+    return f"<{cls.__module__}.{cls.__qualname__}>"
+
+
+# This function will be called when creating a context and should register
+# a few default machines for certain roles.  Any registration here **must**
+# use weak=True!
+def _register_default_machines(ctx: "tbot.Context") -> None:
+    # Use the 'LocalLabHost' from the selectable module as a default lab- and
+    # local-host for now.
+    from tbot.selectable import LocalLabHost
+
+    ctx.register(LocalLabHost, [LabHost, LocalHost], weak=True)
+
+    # We need to provide a build-host that maps to the actual build-host
+    # defined by the legacy build() method on the lab-host.
+    class BuildHostProxy:
+        @classmethod
+        @contextlib.contextmanager
+        def from_context(cls, ctx: tbot.Context) -> Iterator:
+            with contextlib.ExitStack() as cx:
+                lh = cx.enter_context(ctx.request(LabHost))
+                with lh.build() as bh:
+                    # It's a common bug that people just return `self` from
+                    # lh.build().  Detect this and manually create a bh clone:
+                    if bh is lh:
+                        tbot.log.warning(
+                            """\
+The build() method for the selected lab should not return `self` but instead `self.clone()`.
+    Attempting to call build_host.clone() automatically now ..."""
+                        )
+                        bh = cx.enter_context(bh.clone())
+
+                    # Do a dirty trick to make `bh` actually a ProxyBuildHost
+                    # so the Context doesn't get alarmed by us returning an
+                    # instance of the wrong type.
+                    wrapper_class = types.new_class(
+                        "BuildHostProxy", (bh.__class__, BuildHostProxy)
+                    )
+                    bh.__class__ = wrapper_class
+
+                    yield bh
+
+    ctx.register(BuildHostProxy, [BuildHost], weak=True)  # type: ignore

--- a/tbot/selectable.py
+++ b/tbot/selectable.py
@@ -15,6 +15,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import typing
+import contextlib
+from typing import Any, Callable, Iterator
+
+import tbot
 from tbot.machine import connector, linux, board
 
 
@@ -25,6 +29,33 @@ class LocalLabHost(
 
 
 LabHost = LocalLabHost
+
+
+@contextlib.contextmanager
+def _inject_into_context(
+    ctx: "tbot.Context", role: Callable[..., "tbot.role.Role"], instance: Any
+) -> Iterator:
+    did_register = False
+    did_inject = False
+
+    try:
+        if role not in ctx._roles:
+            ctx.register(type(instance), role)
+            did_register = True
+
+        if type(instance) not in ctx._instances:
+            ctx._instances[type(instance)] = instance
+            did_inject = True
+
+        yield None
+    finally:
+        if did_register:
+            del ctx._roles[role]  # type: ignore
+
+        # If only the outer context from the acquire_* function is active any
+        # more, remove from context again.
+        if did_inject and instance._rc == 1:
+            del ctx._instances[type(instance)]
 
 
 def acquire_lab() -> LabHost:
@@ -55,7 +86,13 @@ def acquire_lab() -> LabHost:
     """
     if hasattr(LabHost, "_unselected"):
         raise NotImplementedError("Maybe you haven't set a lab?")
-    return LabHost()
+
+    @contextlib.contextmanager
+    def _internal() -> Any:
+        with LabHost() as lh, _inject_into_context(tbot.ctx, tbot.role.LabHost, lh):
+            yield lh
+
+    return _internal()  # type: ignore
 
 
 def acquire_local() -> LocalLabHost:
@@ -79,7 +116,14 @@ def acquire_local() -> LocalLabHost:
                 # On local machines you can access tbot's working directory:
                 tbot.log.message(f"CWD: {lo.workdir}")
     """
-    return LocalLabHost()
+
+    @contextlib.contextmanager
+    def _internal() -> Any:
+        with LocalLabHost() as lo:
+            with _inject_into_context(tbot.ctx, tbot.role.LocalHost, lo):
+                yield lo
+
+    return _internal()  # type: ignore
 
 
 class Board(board.Board):
@@ -111,7 +155,14 @@ def acquire_board(lh: LabHost) -> Board:
     """
     if hasattr(Board, "_unselected"):
         raise NotImplementedError("Maybe you haven't set a board?")
-    return Board(lh)  # type: ignore
+
+    @contextlib.contextmanager
+    def _internal() -> Any:
+        with Board(lh) as b:  # type: ignore
+            with _inject_into_context(tbot.ctx, tbot.role.Board, b):
+                yield b
+
+    return _internal()  # type: ignore
 
 
 class UBootMachine(board.UBootShell, typing.ContextManager):
@@ -158,7 +209,14 @@ def acquire_uboot(board: Board, *args: typing.Any) -> UBootMachine:
     """
     if hasattr(UBootMachine, "_unselected"):
         raise NotImplementedError("Maybe you haven't set a board?")
-    return UBootMachine(board, *args)  # type: ignore
+
+    @contextlib.contextmanager
+    def _internal() -> Any:
+        with UBootMachine(board, *args) as ub:  # type: ignore
+            with _inject_into_context(tbot.ctx, tbot.role.BoardUBoot, ub):
+                yield ub
+
+    return _internal()  # type: ignore
 
 
 class LinuxMachine(board.LinuxBootLogin, linux.LinuxShell, typing.ContextManager):
@@ -207,4 +265,11 @@ def acquire_linux(
     """
     if hasattr(LinuxMachine, "_unselected"):
         raise NotImplementedError("Maybe you haven't set a board?")
-    return LinuxMachine(b, *args)  # type: ignore
+
+    @contextlib.contextmanager
+    def _internal() -> Any:
+        with LinuxMachine(b, *args) as lnx:  # type: ignore
+            with _inject_into_context(tbot.ctx, tbot.role.BoardLinux, lnx):
+                yield lnx
+
+    return _internal()  # type: ignore

--- a/tbot_contrib/connector/pyserial.py
+++ b/tbot_contrib/connector/pyserial.py
@@ -1,6 +1,7 @@
 import abc
 import os
 import typing
+import contextlib
 
 import tbot.error
 from tbot.machine import channel, connector, linux
@@ -80,6 +81,9 @@ class PyserialChannel(channel.Channel):
         super().__init__(PyserialChannelIO(port, baudrate))
 
 
+M = typing.TypeVar("M", bound="PyserialConnector")
+
+
 class PyserialConnector(connector.Connector):
     """
     Connect to a console connected to **localhost** (i.e. the host tbot is
@@ -114,6 +118,12 @@ class PyserialConnector(connector.Connector):
                 "PyserialConnector can only use a localhost host (got {host!r})!"
             )
         self.host = host
+
+    @classmethod
+    @contextlib.contextmanager
+    def from_context(cls: typing.Type[M], ctx: "tbot.Context") -> typing.Iterator[M]:
+        with cls() as m:
+            yield m
 
     def _connect(self) -> channel.Channel:
         return PyserialChannel(self.serial_port, self.baudrate)


### PR DESCRIPTION
The existing `tbot.selectable` module is a glorified hack for bridging between the selected config and the testcases.  As tbot aims to support more and more complex use-cases, it becomes apparent that this existing mechanism is not sufficient.

The "Context" is an attempt to solve this problem:  It is a central "machine manager" where the config registers available machine classes and testcases request instances from.  The idea is to have global management of instances so testcases need not concern themselves with creating and passing instances around.  Instead, the manager keeps the instances at the ready for any testcase that needs access.

A few quick examples:

#### Testcase with just Linux on the board
```python
@tbot.testcase
def test_board_linux() -> None:
    with tbot.ctx.request(tbot.role.BoardLinux) as lnx:
        lnx.exec0("uname", "-a")
```

#### Testcase with Lab-Host and board's U-Boot
```python
@tbot.testcase
def test_multiple_machines() -> None:
    with tbot.ctx() as cx:
        lh = cx.request(tbot.role.LabHost)
        ub = cx.request(tbot.role.BoardUBoot)

        lh.exec0("uname", "-a")
        ub.exec0("version")
```

#### New-style lab configuration
```python
class MyLabHost(connector.SSHConnector, linux.Bash):
    name = "foo-lab-host"

    @property
    def workdir(self):
        return linux.Workdir.xdg_data("tbot-foo-lab")

# This function is called by tbot when loading the configuration and should
# register all machines into the given context
def register_machines(ctx):
    ctx.register(MyLabHost, tbot.role.LabHost)
```

The "context" API is compatible with `tbot.selectble` for the time being.  This means, old configuration will work with new testcases and new configuration will work with old testcases.

For more details, please refer to the [context documentation](https://github.com/Rahix/tbot/blob/context/Documentation/context.rst) in this PR.