### PR TITLE
machine: Add additional initializer contexts

### DIFF
--- a/Documentation/modules/machine.rst
+++ b/Documentation/modules/machine.rst
@@ -74,3 +74,11 @@ Initializers
 .. autoclass:: tbot.machine.Initializer
    :members:
    :private-members:
+
+.. autoclass:: tbot.machine.PreConnectInitializer
+   :members:
+   :private-members:
+
+.. autoclass:: tbot.machine.PostShellInitializer
+   :members:
+   :private-members:

--- a/tbot/machine/__init__.py
+++ b/tbot/machine/__init__.py
@@ -2,6 +2,15 @@ from . import board
 from . import connector
 from . import shell
 from . import linux
-from .machine import Machine, Initializer
+from .machine import Initializer, Machine, PostShellInitializer, PreConnectInitializer
 
-__all__ = ("Machine", "board", "connector", "linux", "shell", "Initializer")
+__all__ = (
+    "Machine",
+    "board",
+    "connector",
+    "linux",
+    "shell",
+    "Initializer",
+    "PreConnectInitializer",
+    "PostShellInitializer",
+)


### PR DESCRIPTION
Add pre-connection and post-shell initializer contexts, which run
before and after the existing Initializer context, for additional
flexibility.

Signed-off-by: Niel Fourie <lusus@denx.de>