### PR TITLE
Add more features to Context mechanism

### DIFF
--- a/tbot/context.py
+++ b/tbot/context.py
@@ -103,6 +103,13 @@ class Context(typing.ContextManager):
     You will usually access the global context :py:data:`tbot.ctx` which is an
     instance of this class instead of instanciating :py:class:`tbot.Context`
     yourself.  See the :ref:`context` guide for a detailed introduction.
+
+    In case you do need to construct a context yourself, there are a few
+    customization possibilities:
+
+    :param bool add_defaults: Add default machines for some roles from
+        :py:mod:`tbot.role`, for example for :py:class:`tbot.role.LocalHost`.
+        Defaults to ``False``.
     """
 
     def __init__(self, *, add_defaults: bool = False) -> None:

--- a/tbot/machine/linux/ash.py
+++ b/tbot/machine/linux/ash.py
@@ -226,7 +226,7 @@ class Ash(linux_shell.LinuxShell):
     @contextlib.contextmanager
     def subshell(
         self: Self, *args: typing.Union[str, special.Special[Self], path.Path[Self]]
-    ) -> "typing.Iterator[Ash]":
+    ) -> typing.Iterator[Self]:
         if args == ():
             cmd = "ash"
         else:


### PR DESCRIPTION
This series adds two more features to the `Context`s:

1. The `keep_alive` mode in which the `Context` keeps instances alive even after the last "user" exits.  This means follow-up `request()`s will get the "old" instance instead of having to initialize a new one.
2. The `reset_on_error` request-mode where an exception while the instance is life will trigger teardown of the instance.  In conjunction with `keep_alive` this is important to make sure an unrelated request later on will get clean instance, even if a failure occured during the earlier request.