### PR TITLE
Reimplement selftests with pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: tbot selftest CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - wip
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies, linters, doc-tools
         run: |
           python -m pip install --upgrade pip
-          pip install junit-xml mypy paramiko termcolor2 pyserial
+          pip install pytest mypy paramiko termcolor2 pyserial
       - name: Run pre-commit hooks for all files
         uses: pre-commit/action@v2.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
         uses: pre-commit/action@v2.0.0
         with:
           extra_args: --all-files --verbose
-      - name: Run tbot selftests
-        run: |
-          env CLICOLOR_FORCE=1 python -m tbot.main -vv selftest
       - name: Run tbot extended selftests
         run: |
           env CLICOLOR_FORCE=1 python -m tbot.main -vv selftest_tc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,26 +29,11 @@ repos:
 -   repo: local
     hooks:
     - id: selftests
-      name: tbot selftest
+      name: Run tbot selftest test-suite
       language: system
-      entry: python3 -c "__import__('sys').argv = ['tbot', '--log', '/tmp/tbot-log.json', '-vv', 'selftest']; __import__('tbot.main').main.main()"
+      entry: python3 -m pytest selftest/
       files: ^.*\.py$
       pass_filenames: false
-      require_serial: true
-    - id: generator_html
-      name: tbot HTML log generator
-      language: system
-      entry: sh -c "./generators/htmllog.py /tmp/tbot-log.json >/dev/null"
-      files: ^.*\.py$
-      pass_filenames: false
-      require_serial: true
-    - id: generator_junit
-      name: tbot junit generator
-      language: system
-      entry: sh -c "./generators/junit.py /tmp/tbot-log.json >/dev/null"
-      files: ^.*\.py$
-      pass_filenames: false
-      require_serial: true
     - id: static_tests
       name: tbot type system tests
       language: system

--- a/selftest/conftest.py
+++ b/selftest/conftest.py
@@ -1,0 +1,29 @@
+from typing import Any, Callable, ContextManager, Iterator
+
+import pytest
+import tbot
+
+import testmachines
+
+
+@pytest.fixture(scope="session")
+def tbot_context() -> Iterator[tbot.Context]:
+    tbot.log.VERBOSITY = tbot.log.Verbosity.STDOUT
+    tbot.log.NESTING = 1
+    with tbot.Context(keep_alive=True, reset_on_error_by_default=True) as ctx:
+        testmachines.register_machines(ctx)
+
+        yield ctx
+
+
+AnyLinuxShell = Callable[[], ContextManager[tbot.machine.linux.LinuxShell]]
+
+
+@pytest.fixture(
+    scope="module", params=[testmachines.LocalhostBash, testmachines.LocalhostAsh]
+)
+def any_linux_shell(tbot_context: tbot.Context, request: Any) -> AnyLinuxShell:
+    def inner() -> ContextManager[tbot.machine.linux.LinuxShell]:
+        return tbot_context.request(request.param)
+
+    return inner

--- a/selftest/conftest.py
+++ b/selftest/conftest.py
@@ -23,6 +23,7 @@ AnyLinuxShell = Callable[[], ContextManager[tbot.machine.linux.LinuxShell]]
     scope="module",
     params=[
         testmachines.LocalhostBash,
+        testmachines.LocalhostSlowBash,
         testmachines.LocalhostAsh,
         testmachines.MocksshClient,
     ],

--- a/selftest/conftest.py
+++ b/selftest/conftest.py
@@ -20,7 +20,12 @@ AnyLinuxShell = Callable[[], ContextManager[tbot.machine.linux.LinuxShell]]
 
 
 @pytest.fixture(
-    scope="module", params=[testmachines.LocalhostBash, testmachines.LocalhostAsh]
+    scope="module",
+    params=[
+        testmachines.LocalhostBash,
+        testmachines.LocalhostAsh,
+        testmachines.MocksshClient,
+    ],
 )
 def any_linux_shell(tbot_context: tbot.Context, request: Any) -> AnyLinuxShell:
     def inner() -> ContextManager[tbot.machine.linux.LinuxShell]:

--- a/selftest/mypy.ini
+++ b/selftest/mypy.ini
@@ -1,0 +1,22 @@
+[mypy]
+python_version = 3.6
+mypy_path = ../stubs/:./
+warn_incomplete_stub = True
+warn_redundant_casts = True
+warn_unused_configs = False
+incremental = True
+
+check_untyped_defs = True
+disallow_any_unimported = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+no_implicit_optional = True
+strict_optional = True
+warn_return_any = True
+warn_unused_ignores = False
+
+[mypy-tbot.tc.callable]
+ignore_errors = True

--- a/selftest/testmachines.py
+++ b/selftest/testmachines.py
@@ -35,6 +35,20 @@ class LocalhostBash(connector.ConsoleConnector, linux.Bash, tbot.role.Role):
         return mach.open_channel("bash", "--norc", "--noprofile")
 
 
+class LocalhostSlowBash(LocalhostBash, tbot.role.Role):
+    name = "local-slow-bash"
+
+    @property
+    def workdir(self) -> linux.Path:
+        return linux.Workdir.xdg_runtime(self, "selftest-data-bash-slow")
+
+    def connect(self, mach: linux.LinuxShell) -> channel.Channel:
+        ch = super().connect(mach)
+        # Make the channel read one byte at a time, simulating a slow connection
+        ch.READ_CHUNK_SIZE = 1
+        return ch
+
+
 class LocalhostAsh(connector.ConsoleConnector, linux.Ash, tbot.role.Role):
     name = "local-ash"
 
@@ -257,6 +271,7 @@ class MockhwBoardUBoot(
 def register_machines(ctx: tbot.Context) -> None:
     ctx.register(Localhost, [Localhost, tbot.role.LabHost, tbot.role.LocalHost])
     ctx.register(LocalhostBash, [LocalhostBash])
+    ctx.register(LocalhostSlowBash, [LocalhostSlowBash])
     ctx.register(LocalhostAsh, [LocalhostAsh])
     ctx.register(MocksshServer, [MocksshServer])
     ctx.register(MocksshClient, [MocksshClient])

--- a/selftest/testmachines.py
+++ b/selftest/testmachines.py
@@ -1,0 +1,67 @@
+import contextlib
+from typing import Iterator, Union
+
+import tbot
+from tbot.machine import channel, connector, linux
+
+
+class Localhost(connector.SubprocessConnector, linux.Bash, tbot.role.Role):
+    name = "local"
+
+    @property
+    def workdir(self) -> linux.Path:
+        return linux.Workdir.xdg_runtime(self, "selftest-data")
+
+    def init(self) -> None:
+        self.exec0("rm", "-rf", self.workdir)
+        self.exec0("mkdir", self.workdir)
+
+
+class LocalhostBash(connector.ConsoleConnector, linux.Bash, tbot.role.Role):
+    name = "local-bash"
+
+    @property
+    def workdir(self) -> linux.Path:
+        return linux.Workdir.xdg_runtime(self, "selftest-data-bash")
+
+    def init(self) -> None:
+        self.exec0("rm", "-rf", self.workdir)
+        self.exec0("mkdir", self.workdir)
+
+    def connect(self, mach: linux.LinuxShell) -> channel.Channel:
+        return mach.open_channel("bash", "--norc", "--noprofile")
+
+
+class LocalhostAsh(connector.ConsoleConnector, linux.Ash, tbot.role.Role):
+    name = "local-ash"
+
+    @property
+    def workdir(self) -> linux.Path:
+        return linux.Workdir.xdg_runtime(self, "selftest-data-ash")
+
+    def init(self) -> None:
+        self.exec0("rm", "-rf", self.workdir)
+        self.exec0("mkdir", self.workdir)
+
+    @contextlib.contextmanager
+    def subshell(
+        self, *args: Union[str, linux.special.Special, linux.Path]
+    ) -> "Iterator[LocalhostAsh]":
+        # Patch the shell invocation command if no args are given because we're
+        # not using real `ash` here ...
+        if len(args) == 0:
+            args = ("bash", "--posix", "--norc", "--noprofile")
+
+        with super().subshell(*args):
+            yield self
+
+    def connect(self, mach: linux.LinuxShell) -> channel.Channel:
+        # Make sure the terminal is wide enough to not cause breaks.
+        mach.exec0("stty", "cols", "1024")
+        return mach.open_channel("bash", "--posix", "--norc", "--noprofile")
+
+
+def register_machines(ctx: tbot.Context) -> None:
+    ctx.register(Localhost, [Localhost, tbot.role.LabHost])
+    ctx.register(LocalhostBash, [LocalhostBash])
+    ctx.register(LocalhostAsh, [LocalhostAsh])

--- a/selftest/testmachines.py
+++ b/selftest/testmachines.py
@@ -1,8 +1,11 @@
 import contextlib
 from typing import Iterator, Union
 
+import pytest
 import tbot
+from tbot import machine
 from tbot.machine import channel, connector, linux
+from tbot.tc import shell
 
 
 class Localhost(connector.SubprocessConnector, linux.Bash, tbot.role.Role):
@@ -61,7 +64,116 @@ class LocalhostAsh(connector.ConsoleConnector, linux.Ash, tbot.role.Role):
         return mach.open_channel("bash", "--posix", "--norc", "--noprofile")
 
 
+class MocksshServer(
+    connector.SubprocessConnector,
+    linux.Bash,
+    machine.PostShellInitializer,
+    tbot.role.Role,
+):
+    name = "mockssh-server"
+
+    @property
+    def workdir(self) -> linux.Path:
+        return linux.Workdir.xdg_runtime(self, "selftest-data-ssh")
+
+    @contextlib.contextmanager
+    def _init_post_shell(self) -> Iterator[None]:
+        # Make sure all requirements are available
+        for tool in ["ssh", "ssh-keygen", "sshd"]:
+            if not shell.check_for_tool(self, tool):
+                pytest.skip(f"Skipping ssh tests because `{tool}` is missing.")
+
+        self.exec0("mkdir", "-p", self.workdir)
+        self.exec0("chmod", "0700", self.workdir)
+
+        keyfile = self.workdir / "ssh_host_rsa_key"
+        if not keyfile.exists():
+            self.exec0("ssh-keygen", "-f", keyfile, "-N", "", "-t", "rsa")
+
+        userkey = self.workdir / "id_rsa"
+        userkeypub = self.workdir / "id_rsa.pub"
+        if not userkey.exists():
+            self.exec0("ssh-keygen", "-f", userkey, "-N", "", "-t", "rsa")
+            self.exec0("chmod", "0600", userkeypub)
+
+        self.userkey = userkey
+
+        cat_path = self.exec0("which", "cat").strip()
+
+        sshd_config = self.workdir / "sshd_config"
+        sshd_config.write_text(
+            f"""\
+# Host Key
+HostKeyAlgorithms ssh-rsa
+HostKey {keyfile._local_str()}
+
+# Local Serving
+ListenAddress localhost:18222
+
+# Access
+AuthorizedKeysFile none
+AuthorizedKeysCommand {cat_path} {userkeypub._local_str()}
+AuthorizedKeysCommandUser {self.env("USER")}
+ChallengeResponseAuthentication no
+UsePAM yes
+PasswordAuthentication no
+
+# Environment
+AcceptEnv=XDG_RUNTIME_DIR"""
+        )
+
+        sshd_path = self.exec0("which", "sshd").strip()
+
+        self.exec0(sshd_path, "-D", "-f", sshd_config, linux.Background)
+        sshd_pid = self.env("!")
+
+        try:
+            yield None
+        finally:
+            self.exec0("kill", sshd_pid, linux.Then, "wait", sshd_pid)
+
+
+class MocksshClient(connector.SSHConnector, linux.Bash, tbot.role.Role):
+    name = "mockssh-client"
+
+    # SSH Settings
+    hostname = "localhost"
+    ignore_hostkey = True
+    port = 18222
+    ssh_config = ["UserKnownHostsFile=/dev/null", "SendEnv=XDG_RUNTIME_DIR"]
+    # will be overridden later:
+    authenticator = linux.auth.PrivateKeyAuthenticator("/dev/null")
+
+    @classmethod
+    @contextlib.contextmanager
+    def from_context(cls, ctx: tbot.Context) -> Iterator:
+        with contextlib.ExitStack() as cx:
+            # Start the server
+            srv = cx.enter_context(ctx.request(MocksshServer))
+            # Get a localhost
+            lo = cx.enter_context(ctx.request(tbot.role.LocalHost))
+
+            # Set authenticator
+            cls.authenticator = linux.auth.PrivateKeyAuthenticator(
+                srv.userkey._local_str()
+            )
+
+            # Instanciate self
+            m = cx.enter_context(cls(lo))
+            yield m
+
+    @property
+    def workdir(self) -> linux.Path:
+        return linux.Workdir.xdg_runtime(self, "selftest-data-ssh-client")
+
+    def init(self) -> None:
+        self.exec0("rm", "-rf", self.workdir)
+        self.exec0("mkdir", self.workdir)
+
+
 def register_machines(ctx: tbot.Context) -> None:
-    ctx.register(Localhost, [Localhost, tbot.role.LabHost])
+    ctx.register(Localhost, [Localhost, tbot.role.LabHost, tbot.role.LocalHost])
     ctx.register(LocalhostBash, [LocalhostBash])
     ctx.register(LocalhostAsh, [LocalhostAsh])
+    ctx.register(MocksshServer, [MocksshServer])
+    ctx.register(MocksshClient, [MocksshClient])

--- a/selftest/tests/test_board.py
+++ b/selftest/tests/test_board.py
@@ -1,0 +1,42 @@
+import testmachines
+import tbot
+from tbot.machine import board
+
+
+def test_uboot_simple_commands(tbot_context: tbot.Context) -> None:
+    with tbot_context.request(testmachines.MockhwBoardUBoot) as ub:
+        ub.exec0("version")
+        assert ub.exec0("echo", "Hello World") == "Hello World\n"
+        assert ub.exec0("echo", "$?", "!#") == "$? !#\n"
+
+
+def test_uboot_long_output(tbot_context: tbot.Context) -> None:
+    with tbot_context.request(testmachines.MockhwBoardUBoot) as ub:
+        s = "_".join(map(lambda i: f"{i:02}", range(80)))
+        assert ub.exec0("echo", s) == f"{s}\n"
+
+
+def test_uboot_return_code(tbot_context: tbot.Context) -> None:
+    with tbot_context.request(testmachines.MockhwBoardUBoot) as ub:
+        assert ub.test("true")
+        assert not ub.test("false")
+
+
+def test_uboot_simple_environment(tbot_context: tbot.Context) -> None:
+    with tbot_context.request(testmachines.MockhwBoardUBoot) as ub:
+        value = "12 foo !? # true; exit"
+        ub.env("tbot_test_env_var", value)
+        assert ub.env("tbot_test_env_var") == value
+
+
+def test_uboot_simple_control(tbot_context: tbot.Context) -> None:
+    with tbot_context.request(testmachines.MockhwBoardUBoot) as ub:
+        out = ub.exec0(
+            "false", board.AndThen, "echo", "FOO", board.OrElse, "echo", "BAR"
+        ).strip()
+        assert out == "BAR"
+
+        out = ub.exec0(
+            "true", board.AndThen, "echo", "FOO", board.OrElse, "echo", "BAR"
+        ).strip()
+        assert out == "FOO"

--- a/selftest/tests/test_channel.py
+++ b/selftest/tests/test_channel.py
@@ -1,0 +1,102 @@
+from typing import Iterator, Match
+
+import pytest
+
+import tbot
+from tbot.machine import channel
+
+
+@pytest.fixture
+def ch() -> Iterator[channel.Channel]:
+    with channel.SubprocessChannel() as ch:
+        ch.read()
+
+        # We must ensure that nothing enters the history from the commands sent
+        # in the following tests.
+        ch.sendline("unset HISTFILE", read_back=True)
+        ch.read()
+
+        yield ch
+
+
+def test_simple_command(ch: channel.Channel) -> None:
+    ch.sendline("echo Hello World", read_back=True)
+    out = ch.read()
+    assert out.startswith(b"Hello World")
+
+
+def test_simple_reading(ch: channel.Channel) -> None:
+    ch.write(b"1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+    out = ch.read(10)
+    assert out == b"1234567890"
+
+    out = ch.read()
+    assert out == b"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def test_simple_read_iter(ch: channel.Channel) -> None:
+    ch.write(b"12345678901234567890")
+    final = bytearray()
+    for new in ch.read_iter(10):
+        final.extend(new)
+    assert final == b"1234567890"
+    for i in range(1, 10):
+        c = ch.read(1)
+        assert c == str(i).encode("utf-8")
+
+
+def test_simple_readline(ch: channel.Channel) -> None:
+    ch.sendline("echo Hello; echo World", read_back=True)
+    out_s = ch.readline()
+    assert out_s == "Hello\n"
+    out_s = ch.readline()
+    assert out_s == "World\n"
+
+
+def test_simple_expect(ch: channel.Channel) -> None:
+    ch.sendline("echo Lorem Ipsum")
+    res = ch.expect(["Lol", "Ip"])
+    assert res.i == 1
+    assert res.match == "Ip"
+
+
+def test_simple_expect2(ch: channel.Channel) -> None:
+    ch.sendline("echo Lorem Ipsum Dolor Sit")
+    res = ch.expect(["Lol", "Dolor", "Dol"])
+    assert res.i == 1
+    assert res.match == "Dolor"
+
+
+def test_simple_expect3(ch: channel.Channel) -> None:
+    ch.sendline("echo Lo1337rem")
+    res = ch.expect(["Dolor", "roloD", tbot.Re(r"Lo(\d{1,20})"), "rem"])
+    assert res.i == 2
+    assert isinstance(res.match, Match), "Not a match object"
+    assert res.match.group(1) == b"1337"
+
+
+def test_borrowing(ch: channel.Channel) -> None:
+    ch.sendline("echo Hello")
+
+    with ch.borrow() as ch2:
+        ch2.sendline("echo World")
+
+        raised = False
+        try:
+            ch.sendline("echo Illegal")
+        except channel.ChannelBorrowedException:
+            raised = True
+
+        assert raised, "Borrow was unsuccessful"
+
+    ch.sendline("echo back again")
+
+
+def test_taking(ch: channel.Channel) -> None:
+    ch.sendline("echo Hello")
+
+    ch2 = ch.take()
+    ch2.sendline("echo World")
+
+    with pytest.raises(channel.ChannelTakenException):
+        ch.sendline("echo Illegal")

--- a/selftest/tests/test_context.py
+++ b/selftest/tests/test_context.py
@@ -1,0 +1,191 @@
+import pytest
+import tbot
+import testmachines
+
+
+@tbot.testcase
+def tc_context_simple_usage(ctx: tbot.Context, new: str) -> str:
+    with ctx.request(tbot.role.LabHost) as lh:
+        value = lh.env("TBOT_CTX_TESTS")
+        lh.env("TBOT_CTX_TESTS", new)
+        return value
+
+
+@tbot.testcase
+def tc_context_exclusive_usage(ctx: tbot.Context, new: str) -> str:
+    with ctx.request(tbot.role.LabHost, exclusive=True) as lh:
+        value = lh.env("TBOT_CTX_TESTS")
+        lh.env("TBOT_CTX_TESTS", new)
+
+        with pytest.raises(Exception, match=".*not available.*"):
+            with ctx.request(tbot.role.LabHost):
+                pass
+
+        return value
+
+
+@tbot.testcase
+def tc_context_resetting_usage(ctx: tbot.Context, new: str) -> None:
+    with ctx.request(tbot.role.LabHost, reset=True) as lh:
+        value = lh.env("TBOT_CTX_TESTS")
+        assert value == ""
+        lh.env("TBOT_CTX_TESTS", new)
+
+
+def test_simple_context() -> None:
+    """
+    Simply attempt requesting an instance two times without any interaction.
+    """
+    ctx = tbot.Context()
+    testmachines.register_machines(ctx)
+    with ctx:
+        assert tc_context_simple_usage(ctx, "first") == ""
+        assert tc_context_simple_usage(ctx, "second") == ""
+
+
+def test_nested_context() -> None:
+    """
+    In a nested scenario, the instance should be kept alive and reused for
+    later requests.
+    """
+    ctx = tbot.Context()
+    testmachines.register_machines(ctx)
+    with ctx:
+        with ctx.request(tbot.role.LabHost) as outer:
+            assert tc_context_simple_usage(ctx, "first") == ""
+            assert outer.env("TBOT_CTX_TESTS") == "first"
+            assert tc_context_simple_usage(ctx, "second") == "first"
+            assert outer.env("TBOT_CTX_TESTS") == "second"
+            assert tc_context_simple_usage(ctx, "third") == "second"
+
+
+def test_keep_alive_context() -> None:
+    """
+    A keep-alive context should behave as if it was nested for all instances.
+    """
+    ctx = tbot.Context(keep_alive=True)
+    testmachines.register_machines(ctx)
+    with ctx:
+        assert tc_context_simple_usage(ctx, "first") == ""
+        assert tc_context_simple_usage(ctx, "second") == "first"
+        assert tc_context_simple_usage(ctx, "third") == "second"
+
+
+def test_illegal_keep_alive_context() -> None:
+    """
+    A keep-alive context **must** have its own context-manager active.
+    """
+    ctx = tbot.Context(keep_alive=True)
+    with pytest.raises(tbot.error.TbotException):
+        with ctx.request(tbot.role.LabHost):
+            pass
+
+
+def test_exclusive_context() -> None:
+    """
+    An exclusive instance cannot be re-requested and is torn down on context exit.
+    """
+    ctx = tbot.Context()
+    testmachines.register_machines(ctx)
+    with ctx:
+        with ctx.request(tbot.role.LabHost) as outer:
+            assert tc_context_simple_usage(ctx, "first") == ""
+            outer.exec0("true")
+            assert tc_context_exclusive_usage(ctx, "second") == "first"
+            with pytest.raises(tbot.machine.channel.ChannelClosedException):
+                outer.exec0("true")
+            assert tc_context_simple_usage(ctx, "third") == ""
+
+
+def test_resetting_context() -> None:
+    """
+    An request(reset=True) should always get a pristine instance.
+    """
+    ctx = tbot.Context()
+    testmachines.register_machines(ctx)
+    with ctx:
+        with ctx.request(tbot.role.LabHost) as outer:
+            assert tc_context_simple_usage(ctx, "first") == ""
+            outer.exec0("true")
+            tc_context_resetting_usage(ctx, "second")
+            with pytest.raises(tbot.machine.channel.ChannelClosedException):
+                outer.exec0("true")
+            assert tc_context_simple_usage(ctx, "third") == "second"
+            tc_context_resetting_usage(ctx, "fourth")
+
+
+def test_keep_alive_exclusive_context() -> None:
+    """
+    Test invariants of exclusive access for a keep-alive context.
+    """
+    ctx = tbot.Context(keep_alive=True)
+    testmachines.register_machines(ctx)
+    with ctx:
+        assert tc_context_simple_usage(ctx, "first") == ""
+        assert tc_context_exclusive_usage(ctx, "second") == "first"
+        assert tc_context_simple_usage(ctx, "third") == ""
+
+
+def test_keep_alive_resetting_context() -> None:
+    """
+    Test invariants of resetting access for a keep-alive context.
+    """
+    ctx = tbot.Context(keep_alive=True)
+    testmachines.register_machines(ctx)
+    with ctx:
+        assert tc_context_simple_usage(ctx, "first") == ""
+        tc_context_resetting_usage(ctx, "second")
+        assert tc_context_simple_usage(ctx, "third") == "second"
+        tc_context_resetting_usage(ctx, "fourth")
+
+
+def test_reset_on_error_context() -> None:
+    """
+    Make sure the reset_on_error mode works as intended.
+    """
+    ctx = tbot.Context()
+    testmachines.register_machines(ctx)
+    with ctx:
+        with ctx.request(tbot.role.LabHost) as outer:
+            with pytest.raises(Exception):
+                with ctx.request(tbot.role.LabHost, reset_on_error=True) as inner1:
+                    inner1.env("TBOT_CTX_TESTS", "inner1")
+                    raise Exception()
+
+            with ctx.request(tbot.role.LabHost) as inner2:
+                assert inner2.env("TBOT_CTX_TESTS") != "inner1"
+
+            with pytest.raises(tbot.machine.channel.ChannelClosedException):
+                outer.exec0("true")
+
+
+def test_keep_alive_reset_on_error_context() -> None:
+    """
+    Make sure the reset_on_error mode works as intended, when keep_alive is enabled.
+    """
+    ctx = tbot.Context(keep_alive=True)
+    testmachines.register_machines(ctx)
+    with ctx:
+        with pytest.raises(Exception):
+            with ctx.request(tbot.role.LabHost, reset_on_error=True) as inner1:
+                inner1.env("TBOT_CTX_TESTS", "inner1")
+                raise Exception()
+
+        with ctx.request(tbot.role.LabHost) as inner2:
+            assert inner2.env("TBOT_CTX_TESTS") != "inner1"
+
+
+def test_reset_on_error_by_default_context() -> None:
+    """
+    Make sure the reset_on_error mode works as intended, when keep_alive is enabled.
+    """
+    ctx = tbot.Context(keep_alive=True, reset_on_error_by_default=True)
+    testmachines.register_machines(ctx)
+    with ctx:
+        with pytest.raises(Exception):
+            with ctx.request(tbot.role.LabHost) as inner1:
+                inner1.env("TBOT_CTX_TESTS", "inner1")
+                raise Exception()
+
+        with ctx.request(tbot.role.LabHost) as inner2:
+            assert inner2.env("TBOT_CTX_TESTS") != "inner1"

--- a/selftest/tests/test_interactive_commands.py
+++ b/selftest/tests/test_interactive_commands.py
@@ -1,0 +1,75 @@
+import pytest
+
+from tbot.machine import linux
+from conftest import AnyLinuxShell
+
+
+def test_run_working(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        with linux_shell.run("bash", "--norc", "--noprofile") as bs:
+            bs.sendline("exit")
+            bs.terminate0()
+
+
+def test_run_working_text(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        f = linux_shell.workdir / "test_run.txt"
+        with linux_shell.run("cat", linux.RedirStdout(f)) as cat:
+            cat.sendline("Hello World")
+            cat.sendline("Lorem ipsum")
+
+            cat.sendcontrol("D")
+            cat.terminate0()
+
+        with linux_shell.run("cat", f) as cat:
+            content = cat.terminate0()
+
+        assert content == "Hello World\nLorem ipsum\n"
+
+
+def test_failing_use_after_terminate(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        with linux_shell.run("cat") as cat:
+            cat.sendcontrol("D")
+            cat.terminate0()
+
+            with pytest.raises(linux.CommandEndedException):
+                cat.sendline("Hello World")
+
+            with pytest.raises(Exception):
+                cat.terminate0()
+
+
+def test_failing_unexpected_abort(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        with linux_shell.run("echo", "Hello World", linux.Then, "false") as echo:
+            with pytest.raises(linux.CommandEndedException):
+                echo.read_until_prompt("Lorem Ipsum")
+
+            with pytest.raises(linux.CommandEndedException):
+                echo.sendline("Hello World")
+
+            retcode, _ = echo.terminate()
+            assert retcode == 1, "Did not capture retcode of early exiting command"
+
+
+def test_failing_bad_retcode(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        with pytest.raises(Exception):
+            with linux_shell.run("false") as false:
+                false.terminate0()
+
+        with linux_shell.run("sh", "-c", "exit 123") as sh:
+            rc = sh.terminate()[0]
+            assert rc == 123, f"Expected return code 123, got {rc}"
+
+
+def test_failing_no_terminate(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        with pytest.raises(RuntimeError):
+            with linux_shell.run("echo", "Hello World"):
+                pass
+
+        # Necessary to bring machine back into good state
+        linux_shell.ch.read_until_prompt()
+        linux_shell.exec0("true")

--- a/selftest/tests/test_machine_basics.py
+++ b/selftest/tests/test_machine_basics.py
@@ -1,0 +1,27 @@
+import tbot
+
+import testmachines
+
+
+def test_reentrancy(tbot_context: tbot.Context) -> None:
+    """
+    Check whether you can properly enter a machine context multiple times.
+    """
+    with tbot_context.request(testmachines.Localhost) as lo:
+        with lo as h1:
+            h1.env("TBOT_REENTRANCY", "foobarbaz")
+
+        with lo as h2:
+            assert h2.env("TBOT_REENTRANCY") == "foobarbaz"
+
+        assert lo.env("TBOT_REENTRANCY") == "foobarbaz"
+
+
+def test_clone_hash(tbot_context: tbot.Context) -> None:
+    """
+    A clone should not be the same machine but should have the same hash.
+    """
+    with tbot_context.request(testmachines.Localhost) as lo:
+        with lo.clone() as lo2:
+            assert id(lo) != id(lo2)
+            assert hash(lo) == hash(lo2)

--- a/selftest/tests/test_path.py
+++ b/selftest/tests/test_path.py
@@ -1,0 +1,177 @@
+import contextlib
+from typing import Callable, ContextManager, Iterator, Optional
+
+import pytest
+import tbot
+import testmachines
+from conftest import AnyLinuxShell
+from tbot.machine import linux
+
+TestDir = Callable[[], ContextManager[tbot.machine.linux.Path]]
+
+
+@pytest.fixture
+def testdir_builder(any_linux_shell: AnyLinuxShell) -> TestDir:
+    @contextlib.contextmanager
+    def inner() -> Iterator[tbot.machine.linux.Path]:
+        with any_linux_shell() as linux_shell:
+            testdir = linux_shell.workdir / "path-tests"
+            linux_shell.exec0("rm", "-rf", testdir)
+            linux_shell.exec0("mkdir", testdir)
+            yield testdir
+
+    return inner
+
+
+def get_blockdev(host: linux.LinuxShell) -> Optional[linux.Path]:
+    blockdevices = host.exec(
+        "find", "/dev", "-type", "b", linux.RedirStderr(host.fsroot / "dev" / "null")
+    )[1].splitlines()
+    if blockdevices == []:
+        return None
+    blockdev = linux.Path(host, blockdevices[0])
+    assert blockdev.is_block_device()
+    return blockdev
+
+
+def test_integrity(tbot_context: tbot.Context) -> None:
+    with tbot_context.request(testmachines.Localhost) as lo:
+        p = lo.workdir / "abcdef"
+
+        with testmachines.Localhost() as lo2:
+            with pytest.raises(tbot.error.WrongHostError):
+                # MYPY knows this is wrong :)
+                lo2.exec0("echo", p)  # type: ignore
+
+        with lo.clone() as lo3:
+            lo3.exec0("echo", p)
+
+
+def test_missing(testdir_builder: TestDir) -> None:
+    with testdir_builder() as testdir:
+        missing = testdir / "a-file-that-does-not-exist"
+        assert not missing.exists()
+
+        assert not missing.is_dir()
+        assert not missing.is_file()
+        assert not missing.is_symlink()
+        assert not missing.is_block_device()
+        assert not missing.is_char_device()
+        assert not missing.is_fifo()
+        assert not missing.is_socket()
+
+
+def test_directory(testdir_builder: TestDir) -> None:
+    with testdir_builder() as testdir:
+        directory = testdir / "directory"
+        testdir.host.exec0("mkdir", directory)
+        assert directory.exists()
+        assert directory.is_dir()
+        assert not directory.is_file()
+        assert not directory.is_symlink()
+
+
+def test_blockdev(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        blockdev = get_blockdev(linux_shell)
+        if blockdev is None:
+            pytest.skip(f"Could not find any blockdevices on this host")
+        assert blockdev.is_block_device()
+
+        assert not blockdev.is_dir()
+        assert not blockdev.is_file()
+        assert not blockdev.is_symlink()
+        assert not blockdev.is_char_device()
+        assert not blockdev.is_fifo()
+        assert not blockdev.is_socket()
+
+
+def test_symlink(testdir_builder: TestDir) -> None:
+    with testdir_builder() as testdir:
+        target = testdir / "symlink-target"
+        symlink = testdir / "symlink"
+        testdir.host.exec0("ln", "-s", target, symlink)
+
+        # Deadlink right now
+        assert symlink.is_symlink()
+        assert not symlink.exists()
+        assert not symlink.is_file()
+
+        # Create the target
+        testdir.host.exec0("touch", target)
+        assert symlink.is_symlink()
+        assert symlink.exists()
+        # TODO: Is this correct?
+        assert symlink.is_file()
+
+
+def test_fifo(testdir_builder: TestDir) -> None:
+    with testdir_builder() as testdir:
+        fifo = testdir / "fifo"
+        testdir.host.exec0("mkfifo", fifo)
+        assert fifo.exists()
+        assert fifo.is_fifo()
+
+
+def test_stat(any_linux_shell: AnyLinuxShell) -> None:
+    import stat
+
+    with any_linux_shell() as linux_shell:
+        stat_list = [
+            (linux.Path(linux_shell, "/dev"), stat.S_ISDIR),
+            (linux.Path(linux_shell, "/proc/version"), stat.S_ISREG),
+            (linux.Path(linux_shell, "/dev/tty"), stat.S_ISCHR),
+        ]
+
+        blockdev = get_blockdev(linux_shell)
+        if blockdev is not None:
+            stat_list.insert(3, (blockdev, stat.S_ISBLK))
+
+        for p, check in stat_list:
+            assert check(p.stat().st_mode)
+
+
+def test_text_io(testdir_builder: TestDir) -> None:
+    with testdir_builder() as testdir:
+        f = testdir / "test-file.txt"
+        content = "This is a test file\nwith multiple lines.\n"
+
+        f.write_text(content)
+        output = f.read_text()
+
+        assert output == content
+
+
+def test_binary_io(testdir_builder: TestDir) -> None:
+    with testdir_builder() as testdir:
+        f = testdir / "test-file.bin"
+        content = b"\x00\x1b[m\x04\x01\x10"
+
+        f.write_bytes(content)
+        output = f.read_bytes()
+
+        assert output == content
+
+
+def test_write_dir_text(testdir_builder: TestDir) -> None:
+    with testdir_builder() as testdir:
+        path = testdir / "test-dir"
+        testdir.host.exec0("mkdir", "-p", path)
+
+        with pytest.raises(Exception):
+            path.write_text("Hello World\n")
+
+        with pytest.raises(Exception):
+            path.read_text()
+
+
+def test_write_dir_binary(testdir_builder: TestDir) -> None:
+    with testdir_builder() as testdir:
+        path = testdir / "test-dir"
+        testdir.host.exec0("mkdir", "-p", path)
+
+        with pytest.raises(Exception):
+            path.write_bytes(b"\x01\x02")
+
+        with pytest.raises(Exception):
+            path.read_bytes()

--- a/selftest/tests/test_shell.py
+++ b/selftest/tests/test_shell.py
@@ -1,0 +1,135 @@
+import pytest
+from tbot.machine import linux
+from tbot.tc import shell
+from conftest import AnyLinuxShell
+
+
+def test_simple_output(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        out = linux_shell.exec0("echo", "Hello World")
+        assert out == "Hello World\n"
+
+        out = linux_shell.exec0("echo", "$?", "!#")
+        assert out == "$? !#\n"
+
+
+def test_simple_printf(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        if not shell.check_for_tool(linux_shell, "printf"):
+            pytest.skip("`printf` missing on this shell")
+
+        out = linux_shell.exec0("printf", "Hello World")
+        assert out == "Hello World"
+
+        out = linux_shell.exec0("printf", "Hello\\nWorld")
+        assert out == "Hello\nWorld"
+
+        out = linux_shell.exec0("printf", "Hello\nWorld")
+        assert out == "Hello\nWorld"
+
+
+def test_long_output(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        s = "_".join(map(lambda i: f"{i:02}", range(80)))
+        out = linux_shell.exec0("echo", s)
+        assert out == f"{s}\n", repr(out)
+
+
+def test_return_code(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        assert linux_shell.test("true")
+        assert not linux_shell.test("false")
+
+        for i in range(256):
+            ret = linux_shell.exec("sh", "-c", f"exit {i}")[0]
+            assert ret == i
+
+
+def test_simple_environment(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        value = "12\nfoo !? # true; exit\n"
+        linux_shell.env("TBOT_TEST_ENV_VAR", value)
+        out = linux_shell.env("TBOT_TEST_ENV_VAR")
+        assert out == value, repr(out)
+
+
+def test_redirection(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        f = linux_shell.workdir / ".redir test.txt"
+        if f.exists():
+            linux_shell.exec0("rm", f)
+
+        linux_shell.exec0("echo", "Some data - And some more", linux.RedirStdout(f))
+
+        out = f.read_text()
+        assert out == "Some data - And some more\n"
+
+
+def test_subshell(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        # Only on the localhost because the "ash" hack is currently not working
+        linux_shell.env("TBOT_SUBSHELL_TEST", "NUMBER_ONE")
+        with linux_shell.subshell():
+            linux_shell.env("TBOT_SUBSHELL_TEST", "SECOND_PLACE")
+            with linux_shell.subshell():
+                linux_shell.env("TBOT_SUBSHELL_TEST", "INNERMOST")
+                assert linux_shell.env("TBOT_SUBSHELL_TEST") == "INNERMOST"
+            assert linux_shell.env("TBOT_SUBSHELL_TEST") == "SECOND_PLACE"
+        assert linux_shell.env("TBOT_SUBSHELL_TEST") == "NUMBER_ONE"
+
+
+def test_simple_control(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        out = linux_shell.exec0(
+            "false", linux.AndThen, "echo", "FOO", linux.OrElse, "echo", "BAR"
+        ).strip()
+        assert out == "BAR"
+
+        out = linux_shell.exec0(
+            "true", linux.AndThen, "echo", "FOO", linux.OrElse, "echo", "BAR"
+        ).strip()
+        assert out == "FOO"
+
+
+def test_simple_jobs(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        import re
+        import time
+
+        t1 = time.monotonic()
+        out = linux_shell.exec0(
+            "sleep", "infinity", linux.Background, "echo", "Hello World"
+        ).strip()
+        t2 = time.monotonic()
+        pid = linux_shell.env("!")
+
+        assert re.match(r"\[\d+\] \d+\nHello World", out), repr(out)
+        assert (
+            t2 - t1
+        ) < 9.0, f"Command took {t2 - t1}s (max 9s). Sleep was not sent to background"
+
+        # Kill the sleep process.  In some circumstances, tbot does not
+        # seem to be able to kill all child processes of a subprocess
+        # channel.  To prevent this from leading to issues, kill the sleep
+        # right here instead of relying on tbot to do so correctly at the
+        # very end.      Tracking-Issue: Rahix/tbot#13
+        linux_shell.exec("kill", pid, linux.Then, "wait", pid)
+
+
+def test_background_jobs(any_linux_shell: AnyLinuxShell) -> None:
+    with any_linux_shell() as linux_shell:
+        f1 = linux_shell.workdir / "bg1.txt"
+        f2 = linux_shell.workdir / "bg2.txt"
+        out = linux_shell.exec0(
+            "echo",
+            "foo",
+            linux.Background(stdout=f1),
+            "echo",
+            "bar",
+            linux.Background(stdout=f2, stderr=f2),
+            "wait",
+        )
+        out = f1.read_text().strip()
+        assert out == "foo"
+        out = f2.read_text().strip()
+        assert out == "bar"

--- a/stubs/pytest.pyi
+++ b/stubs/pytest.pyi
@@ -1,0 +1,77 @@
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Generator,
+    Iterable,
+    NoReturn,
+    Optional,
+    Pattern,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
+
+def skip(msg: str = "", *, allow_module_level: bool = False) -> NoReturn: ...
+
+# _Scope = Literal["session", "package", "module", "class", "function"]
+_Scope = str
+# The value of the fixture -- return/yield of the fixture function (type variable).
+_FixtureValue = TypeVar("_FixtureValue")
+# The type of the fixture function (type variable).
+_FixtureFunction = TypeVar("_FixtureFunction", bound=Callable[..., object])
+# The type of a fixture function (type alias generic in fixture value).
+_FixtureFunc = Union[
+    Callable[..., _FixtureValue], Callable[..., Generator[_FixtureValue, None, None]]
+]
+
+class FixtureFunctionMarker:
+    def __call__(self, function: _FixtureFunction) -> _FixtureFunction: ...
+
+@overload
+def fixture(
+    fixture_function: _FixtureFunction,
+    *,
+    scope: "Union[_Scope, Callable[[str, Any], _Scope]]" = ...,
+    params: Optional[Iterable[object]] = ...,
+    autouse: bool = ...,
+    ids: Optional[
+        Union[
+            Iterable[Union[None, str, float, int, bool]],
+            Callable[[Any], Optional[object]],
+        ]
+    ] = ...,
+    name: Optional[str] = ...,
+) -> _FixtureFunction: ...
+@overload
+def fixture(
+    fixture_function: None = ...,
+    *,
+    scope: "Union[_Scope, Callable[[str, Any], _Scope]]" = ...,
+    params: Optional[Iterable[object]] = ...,
+    autouse: bool = ...,
+    ids: Optional[
+        Union[
+            Iterable[Union[None, str, float, int, bool]],
+            Callable[[Any], Optional[object]],
+        ]
+    ] = ...,
+    name: Optional[str] = None,
+) -> FixtureFunctionMarker: ...
+
+_E = TypeVar("_E", bound=BaseException)
+@overload
+def raises(
+    expected_exception: Union[Type[_E], Tuple[Type[_E], ...]],
+    *,
+    match: Optional[Union[str, Pattern[str]]] = ...,
+) -> ContextManager: ...
+@overload
+def raises(
+    expected_exception: Union[Type[_E], Tuple[Type[_E], ...]],
+    func: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> ContextManager: ...

--- a/tbot/machine/linux/ash.py
+++ b/tbot/machine/linux/ash.py
@@ -64,20 +64,15 @@ class Ash(linux_shell.LinuxShell):
 
             # Set prompt to a known string
             #
-            # `read_back=True` is needed here so the following
-            # read_until_prompt() will not accidentally detect the prompt in
-            # the sent command if the connection is slow.
-            #
-            # To safeguard the process even further, the prompt is mangled in a
-            # way which will be unfolded by the shell.  This will ensure tbot
-            # won't accidentally read the prompt back early.
+            # The prompt is mangled in a way which will be unfolded by the
+            # shell.  This will ensure tbot won't accidentally read the prompt
+            # back early if the connection is slow.
             self.ch.sendline(
                 b"PROMPT_COMMAND=''; PS1='"
                 + TBOT_PROMPT[:6]
                 + b"''"
                 + TBOT_PROMPT[6:]
                 + b"'",
-                read_back=True,
             )
             self.ch.prompt = TBOT_PROMPT
             self.ch.read_until_prompt()

--- a/tbot/machine/linux/bash.py
+++ b/tbot/machine/linux/bash.py
@@ -94,7 +94,7 @@ class Bash(linux_shell.LinuxShell):
 
             # Set terminal size
             termsize = shutil.get_terminal_size()
-            self.ch.sendline(f"stty cols {max(40, termsize.columns - 48)}")
+            self.ch.sendline(f"stty cols {max(80, termsize.columns - 48)}")
             self.ch.read_until_prompt()
             self.ch.sendline(f"stty rows {termsize.lines}")
             self.ch.read_until_prompt()


### PR DESCRIPTION
Instead of the custom "test-framework", use [pytest](https://docs.pytest.org/en/stable/index.html) to run tbot's selftests.

I've used this opportunity to demonstrate integration of tbot into a pytest test-suite.  With the `keep_alive` and `reset_on_error` modes of `tbot.Context`, machines are only reset when a failure occurs or it was explicitly requested.  This is extremely useful when testing against real hardware which takes some time to reset.