### PR TITLE
ParamikoConnector: close SSH config file

### DIFF
--- a/tbot/machine/connector/paramiko.py
+++ b/tbot/machine/connector/paramiko.py
@@ -157,7 +157,8 @@ class ParamikoConnector(connector.Connector):
 
             try:
                 c = paramiko.config.SSHConfig()
-                c.parse(open(pathlib.Path.home() / ".ssh" / "config"))
+                with open(pathlib.Path.home() / ".ssh" / "config") as cfg:
+                    c.parse(cfg)
                 self._config = c.lookup(self.hostname)
             except FileNotFoundError:
                 # Config file does not exist


### PR DESCRIPTION
the previous use leaves the file open for a while, triggering a
ResourceWarning. by using a context manager we avoid that problem.

Signed-off-by: Bernhard Kirchen <bernhard.kirchen@mbconnectline.com>