### PR TITLE
linux.Path: implement rmdir and unlink methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added a mechanism for "locking" connections to certain machines.  This can be
   used, for example, to ensure exlusive access to a certain board.  See
   [`tbot_contrib.locking`][tbot-locking] for details.
+- `Path.rmdir()` and `Path.unlink()`: Methods to conveniently delete an empty
+  directory, a symlink, or a file from a host's filesystem.
 
 ### Fixed
 - Fixed the `PyserialConnector` not working properly with tbot contexts.

--- a/tbot/machine/linux/path.py
+++ b/tbot/machine/linux/path.py
@@ -311,6 +311,34 @@ class Path(pathlib.PurePosixPath, typing.Generic[H]):
 
         return base64.b64decode(encoded)
 
+    def rmdir(self) -> None:
+        """
+        Remove the directory pointed to by this path. The directory must be
+        empty.
+        """
+        if self.is_symlink() or not self.is_dir():
+            raise NotADirectoryError
+
+        self.host.exec0("rmdir", self)
+
+    def unlink(self, missing_ok: bool = False) -> None:
+        """
+        Remove the file or symbolic link from the filesystem. If the path points
+        to a directory, use :py:meth:`Path.rmdir()
+        <tbot.machine.linux.Path.rmdir>` instead.
+
+        If ``missing_ok`` is false (the default), ``FileNotFoundError`` is
+        raised if the path does not exist.
+        """
+        if not self.exists():
+            if not missing_ok:
+                raise FileNotFoundError(
+                    errno.ENOENT, os.strerror(errno.ENOENT), str(self)
+                )
+            return
+
+        self.host.exec0("rm", self)
+
     def __truediv__(self, key: typing.Any) -> "Path[H]":
         return Path(self._host, super().__truediv__(key))
 


### PR DESCRIPTION
This is a proposal to implement `unlink()` and `rmdir()` in `tbot.machine.linux.path.Path` to conveniently remove empty directories, symlinks and files from a host's filesystem using the shell commands `rmdir` and `rm`, respectively.

Tests were added/extended to assert reasonable behavior of the new methods.

The unlink method was equipped with a `missing_ok` parameter for compatibility to [`pathlib.Path.unlink()`](https://docs.python.org/3.8/library/pathlib.html#pathlib.Path.unlink).

Signed-off-by: Bernhard Kirchen <bernhard.kirchen@mbconnectline.com>