### PR TITLE
ParamikoConnector: show SSH config parser error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - `Path.rmdir()` and `Path.unlink()`: Methods to conveniently delete an empty
   directory, a symlink, or a file from a host's filesystem.
 
+### Changed
+- Warnings emitted due to problems when parsing the SSH config now include
+  hints about the actual problem.
+
 ### Fixed
 - Fixed the `PyserialConnector` not working properly with tbot contexts.
 

--- a/tbot/machine/connector/paramiko.py
+++ b/tbot/machine/connector/paramiko.py
@@ -163,9 +163,11 @@ class ParamikoConnector(connector.Connector):
             except FileNotFoundError:
                 # Config file does not exist
                 pass
-            except Exception:
+            except Exception as e:
                 # Invalid config
-                tbot.log.warning(tbot.log.c("Invalid").red + " .ssh/config")
+                tbot.log.warning(
+                    tbot.log.c("Invalid").red + f" .ssh/config: {str(e):s}"
+                )
                 raise
 
             if self.ignore_hostkey:


### PR DESCRIPTION
in case an error occurs while trying to parse the SSH config by paramiko or when looking up the config for a particular host, the respective warning now includes the exception's string representation with possibly helpful information about the problem.

in my case I had
`Warning: [...]/tbot/machine/connector/paramiko.py:168: UserWarning: Invalid .ssh/config`
which was not helping at all.

this on the other hand
`Warning: [...]/tbot/machine/connector/paramiko.py:168: UserWarning: Invalid .ssh/config: expected str, bytes or os.PathLike object, not IPv4Address`
helped me immediately. I set an `ipaddress.ip_address` as the hostname.

the gain is also apparent with actual parser problems (missing argument to `IdentityFile` in `~/.ssh/config`):
`Warning: [...]/tbot/machine/connector/paramiko.py:168: UserWarning: Invalid .ssh/config: Unparsable line IdentityFile`

Signed-off-by: Bernhard Kirchen <bernhard.kirchen@mbconnectline.com>