### PR TITLE
machine.linux specials: add Append(Stdout|Stderr|Both)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   directory, a symlink, or a file from a host's filesystem.
 - `Path.mkdir()`: Method to conveniently create a directory on the respective
   machine.
+- New classes `AppendStdout`, `AppendStderr`, and `AppendBoth` in
+  `machine.linux` allow to append command output to files in `exec()` and
+  `exec0()` methods.
 
 ### Changed
 - Warnings emitted due to problems when parsing the SSH config now include

--- a/Documentation/modules/machine_linux.rst
+++ b/Documentation/modules/machine_linux.rst
@@ -136,7 +136,22 @@ can be used to chain multiple commands or to redirect output.
 
 .. py:class:: RedirBoth(file)
 
-   Redirect both ``stdout`` and ``stderr`` (``2>&1 >...``) to a file.
+   Redirect both ``stdout`` and ``stderr`` (``>... 2>&1``) to a file.
+
+.. py:class:: AppendStdout(file)
+
+   Redirect ``stdout`` (``>>...``) to a file, appending to the file rather
+   than overwriting its contents.
+
+.. py:class:: AppendStderr(file)
+
+   Redirect ``stderr`` (``2>>...``) to a file, appending to the file rather
+   than overwriting its contents.
+
+.. py:class:: AppendBoth(file)
+
+   Redirect both ``stdout`` and ``stderr`` (``>>... 2>&1``) to a file,
+   appending to the file rather than overwriting its contents.
 
 .. py:data:: Background
 

--- a/tbot/machine/linux/__init__.py
+++ b/tbot/machine/linux/__init__.py
@@ -28,6 +28,9 @@ from .special import (
     RedirStderr,
     RedirStdout,
     RedirBoth,
+    AppendStderr,
+    AppendStdout,
+    AppendBoth,
     Then,
 )
 from .workdir import Workdir
@@ -56,6 +59,9 @@ __all__ = (
     "RedirStderr",
     "RedirStdout",
     "RedirBoth",
+    "AppendStderr",
+    "AppendStdout",
+    "AppendBoth",
     "Then",
     "Workdir",
     "RunCommandProxy",


### PR DESCRIPTION
- implement the new classes, reusing _Stdio class for RedirBoth and
  AppendBoth by adding a _both property and thus reducing code
  duplication.
- add tests for RedirBoth and RedirStderr, which were previously not
  covered.
- add tests covering the new classes
- add documentation for the new classes
- update changelog