### PR TITLE
Refactor tbot's Path class

### DIFF
--- a/selftest/testmachines.py
+++ b/selftest/testmachines.py
@@ -121,14 +121,14 @@ class MocksshServer(
             f"""\
 # Host Key
 HostKeyAlgorithms ssh-rsa
-HostKey {keyfile._local_str()}
+HostKey {keyfile.at_host(self)}
 
 # Local Serving
 ListenAddress localhost:18222
 
 # Access
 AuthorizedKeysFile none
-AuthorizedKeysCommand {cat_path} {userkeypub._local_str()}
+AuthorizedKeysCommand {cat_path} {userkeypub.at_host(self)}
 AuthorizedKeysCommandUser {self.env("USER")}
 ChallengeResponseAuthentication no
 UsePAM yes
@@ -173,7 +173,7 @@ class MocksshClient(connector.SSHConnector, linux.Bash, tbot.role.Role):
 
             # Set authenticator
             cls.authenticator = linux.auth.PrivateKeyAuthenticator(
-                srv.userkey._local_str()
+                srv.userkey.at_host(srv)
             )
 
             # Instanciate self

--- a/selftest/tests/test_path.py
+++ b/selftest/tests/test_path.py
@@ -36,6 +36,16 @@ def get_blockdev(host: linux.LinuxShell) -> Optional[linux.Path]:
     return blockdev
 
 
+def test_purepath(tbot_context: tbot.Context) -> None:
+    with tbot_context.request(testmachines.Localhost) as lo:
+        p = lo.workdir / "foo" / "bar" / "baz"
+
+        assert p.parent.name == "bar"
+        assert p.parents[0].name == "bar"
+        assert p.parents[1].name == "foo"
+        assert p.parents[2] == lo.workdir
+
+
 def test_integrity(tbot_context: tbot.Context) -> None:
     with tbot_context.request(testmachines.Localhost) as lo:
         p = lo.workdir / "abcdef"

--- a/tbot/machine/linux/path.py
+++ b/tbot/machine/linux/path.py
@@ -81,10 +81,17 @@ class Path(typing.Generic[H]):
                 ret.append(arg)
         return ret
 
+    # tbot specific API {{{
+    # These methods are tbot-specific and do not have an equivalent in pathlib.
     @property
     def host(self) -> H:
         """Host associated with this path."""
         return self._host
+
+    def _local_str(self) -> str:
+        return str(self._path)
+
+    # }}}
 
     # PurePosixPath like API {{{
     # Mimick the API of pathlib's PurePosixPath as much as possible.  This
@@ -164,6 +171,11 @@ class Path(typing.Generic[H]):
         return self._path.match(path_pattern)
 
     # }}}
+
+    # Path like API {{{
+    # Implement some of the methods from pathlib's `Path` class to provide
+    # convenient access to files on the remote host.  All these methods need to
+    # be implemented by using shell commands on the other side.
 
     def stat(self) -> os.stat_result:
         """
@@ -449,8 +461,7 @@ class Path(typing.Generic[H]):
         else:
             self.host.exec0("mkdir", self)
 
-    def _local_str(self) -> str:
-        return str(self._path)
+    # }}}
 
     def __str__(self) -> str:
         return f"{self._host.name}:{self._path}"

--- a/tbot/machine/linux/path.py
+++ b/tbot/machine/linux/path.py
@@ -91,6 +91,19 @@ class Path(typing.Generic[H]):
     def _local_str(self) -> str:
         return str(self._path)
 
+    def at_host(self, host: H) -> str:
+        """
+        Convert this ``Path`` into a string representation assuming it should
+        be valid for the machine ``host``.  An exception is raised if this
+        ``Path`` is for a different machine instead.
+
+        This prevents accidentally using a ``Path`` with the wrong host as much
+        as possible.
+        """
+        if self.host != host:
+            raise tbot.error.WrongHostError(self, host)
+        return str(self._path)
+
     # }}}
 
     # PurePosixPath like API {{{

--- a/tbot/machine/linux/path.py
+++ b/tbot/machine/linux/path.py
@@ -117,7 +117,25 @@ class Path(typing.Generic[H]):
     def __hash__(self) -> int:
         return hash((self._host, self._path))
 
-    # TODO: __lt__, __le__, __gt__, __ge__
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, Path):
+            return NotImplemented
+        return self._path < other._path
+
+    def __le__(self, other: Any) -> bool:
+        if not isinstance(other, Path):
+            return NotImplemented
+        return self._path <= other._path
+
+    def __gt__(self, other: Any) -> bool:
+        if not isinstance(other, Path):
+            return NotImplemented
+        return self._path > other._path
+
+    def __ge__(self, other: Any) -> bool:
+        if not isinstance(other, Path):
+            return NotImplemented
+        return self._path >= other._path
 
     @property
     def name(self) -> str:

--- a/tbot/tc/git.py
+++ b/tbot/tc/git.py
@@ -35,23 +35,6 @@ class ResetMode(enum.Enum):
 class GitRepository(linux.Path[H]):
     """Git repository."""
 
-    def __new__(  # noqa: D102
-        cls,
-        target: linux.Path[H],
-        url: typing.Optional[str] = None,
-        *,
-        clean: bool = True,
-        fetch: bool = True,
-        rev: typing.Optional[str] = None,
-    ) -> "GitRepository[H]":
-        # Casting madness required because parent defines __new__
-        return typing.cast(
-            "GitRepository",
-            super().__new__(
-                typing.cast(typing.Type[linux.Path[H]], cls), target.host, target
-            ),
-        )
-
     def __init__(
         self,
         target: linux.Path[H],


### PR DESCRIPTION
As discussed in #53, the `Path` class was in serious need of some refactoring.  This PR actions on the discussion:

1. Drop the inheritance from pathlib and instead reimplement the API surface manually.
2. By doing this, fix the broken inherited methods like e.g. `.relative_to()`
3. Introduce an `at_host(host)` method for cleanly converting a tbot-path to a string.

Cc: @schlimmchen