### PR TITLE
shell background jobs: redir stderr as expected

### DIFF
--- a/tbot/machine/linux/special.py
+++ b/tbot/machine/linux/special.py
@@ -134,7 +134,7 @@ class _Background(Special[H]):
                 raise tbot.error.WrongHostError(self.stdout, h)
             return f"2>/dev/null 1>{shlex.quote(self.stdout._local_str())} &"
         else:
-            return "2>&1 1>/dev/null &"
+            return "1>/dev/null 2>&1 &"
 
 
 class _Static(Special):


### PR DESCRIPTION
when redirecting stderr (2) to file descriptor 1 *before* redirecting stdout (1) to `/dev/null`, output to stderr will not be redirected to `/dev/null` as expected, but to stdout.

tests are hard to do for this, so I ended up not touchung the respective test in `test_shell.py`.