### PR TITLE
UBootAutobootIntercept: Allow all keys for autoboot interrupt

### DIFF
--- a/tbot/machine/board/uboot.py
+++ b/tbot/machine/board/uboot.py
@@ -114,7 +114,7 @@ class UBootAutobootIntercept(machine.Initializer, UbootStartup):
                     raise TimeoutError(
                         "U-Boot autoboot prompt did not show up in time"
                     ) from None
-                self.ch.send(self.autoboot_keys)
+                self.ch.send(self.autoboot_keys, _ignore_blacklist=True)
 
         yield None
 

--- a/tbot/machine/channel/channel.py
+++ b/tbot/machine/channel/channel.py
@@ -601,6 +601,7 @@ class Channel(typing.ContextManager):
         s: typing.Union[str, bytes],
         read_back: bool = False,
         timeout: typing.Optional[float] = None,
+        _ignore_blacklist: bool = False,
     ) -> None:
         """
         Send data to this channel.
@@ -617,7 +618,7 @@ class Channel(typing.ContextManager):
             return
 
         s = s.encode("utf-8") if isinstance(s, str) else s
-        self.write(s)
+        self.write(s, _ignore_blacklist=_ignore_blacklist)
 
         if read_back:
             # Read back what was just sent.  Assume a well-behaved other side


### PR DESCRIPTION
Hello dev's,

we've using DEL (\x7f) as autoboot interrupt key as also in the [example](https://tbot.tools/modules/machine_board.html#tbot.machine.board.UBootAutobootIntercept), but we're getting the following exception:

```
├─Exception:
│   Traceback (most recent call last):
│     File "/mnt/work/dev/testrack/tbot/tbot/main.py", line 345, in main
│       func(**params)
│     File "/mnt/work/dev/testrack/tbot/tbot/decorators.py", line 62, in wrapped
│       return tc(*args, **kwargs)
│     File "/mnt/work/dev/testrack/tbot/tbot/tc/callable.py", line 50, in interactive_uboot
│       with tbot.ctx.request(tbot.role.BoardUBoot) as ub:
│     File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
│       return next(self.gen)
│     File "/mnt/work/dev/testrack/tbot/tbot/context.py", line 349, in request
│       instance.init(context=machine_class.from_context(self))
│     File "/mnt/work/dev/testrack/tbot/tbot/context.py", line 52, in init
│       self._instance = self._cx.enter_context(context)
│     File "/usr/lib/python3.8/contextlib.py", line 425, in enter_context
│       result = _cm_type.__enter__(cm)
│     File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
│       return next(self.gen)
│     File "/mnt/work/dev/testrack/tbot/tbot/machine/board/board.py", line 119, in from_context
│       m = cx.enter_context(cls(b))  # type: ignore
│     File "/usr/lib/python3.8/contextlib.py", line 425, in enter_context
│       result = _cm_type.__enter__(cm)
│     File "/mnt/work/dev/testrack/tbot/tbot/machine/machine.py", line 163, in __enter__
│       self._cx.enter_context(getattr(cls, "_init_machine")(self))
│     File "/usr/lib/python3.8/contextlib.py", line 425, in enter_context
│       result = _cm_type.__enter__(cm)
│     File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
│       return next(self.gen)
│     File "/mnt/work/dev/testrack/tbot/tbot/machine/board/uboot.py", line 117, in _init_machine
│       self.ch.send(self.autoboot_keys)
│     File "/mnt/work/dev/testrack/tbot/tbot/machine/channel/channel.py", line 620, in send
│       self.write(s)
│     File "/mnt/work/dev/testrack/tbot/tbot/machine/channel/channel.py", line 305, in write
│       raise Exception(
│   Exception: Attempting to write a forbidden byte ('\x7f')!
```

To allow all keys for interrupting autoboot of UBoot, expose `_ignore_blacklist` to `channel.send()` and use it to send the `autoboot_keys` over to the target device.