### PR TITLE
machine.board: Introduce .board property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added a new, reworked integration for U-Boot's test/py testsuite as
   [`tbot_contrib.uboot.testpy`].  Consider using this one in preference of the
   old `tbot.tc.uboot.testpy`.
+- Added a `.board` property to all machines which were instantiated from a
+  "board" (like a `BoardLinux`, for example).  This property points back to
+  this original board machine.  See issue [#65] for a usecase of this.
 
 ### Removed
 - Soft-removed the old selftest suite (which was called with `tbot selftest`)
@@ -23,6 +26,7 @@
   wrong type when an error occurs. This could sometimes even lead to improper
   behavior of follow-up commands.
 
+[#65]: https://github.com/Rahix/tbot/issues/65
 [`tbot_contrib.uboot.testpy`]: https://tbot.tools/contrib/uboot.html#tbot_contrib.uboot.testpy
 
 

--- a/tbot/machine/board/__init__.py
+++ b/tbot/machine/board/__init__.py
@@ -1,14 +1,16 @@
 import typing
+
 import tbot
 
-from .uboot import UBootShell, UBootAutobootIntercept
-from .board import PowerControl, Board, Connector
-from .linux import LinuxUbootConnector, LinuxBootLogin
-from ..linux.special import Then, AndThen, OrElse, Raw
+from .uboot import UBootShell, UBootAutobootIntercept  # isort: skip
+from .board import PowerControl, Board, BoardMachineBase, Connector  # isort: skip
+from .linux import LinuxUbootConnector, LinuxBootLogin  # isort: skip
+from ..linux.special import Then, AndThen, OrElse, Raw  # isort: skip
 
 __all__ = (
     "AndThen",
     "Board",
+    "BoardMachineBase",
     "Connector",
     "LinuxUbootConnector",
     "LinuxBootLogin",

--- a/tbot/machine/board/board.py
+++ b/tbot/machine/board/board.py
@@ -134,10 +134,25 @@ class Board(shell.RawShell):
     pass
 
 
+class BoardMachineBase(abc.ABC):
+    """
+    ABC/Protocol Class for any kind of board machines.
+    """
+
+    @property
+    @abc.abstractmethod
+    def board(self) -> Board:
+        """
+        Returns the instance of the underlying board machine on which this
+        machine is "running".
+        """
+        raise tbot.error.AbstractMethodError()
+
+
 M = typing.TypeVar("M", bound=machine.Machine)
 
 
-class Connector(connector.Connector):
+class Connector(connector.Connector, BoardMachineBase):
     def __init__(self, board: typing.Union[Board, channel.Channel]) -> None:
         if not (isinstance(board, Board) or isinstance(board, channel.Channel)):
             raise TypeError(
@@ -164,3 +179,9 @@ class Connector(connector.Connector):
 
     def clone(self) -> typing.NoReturn:
         raise tbot.error.AbstractMethodError()
+
+    @property
+    def board(self) -> Board:
+        if not isinstance(self._board, Board):
+            raise Exception("this machine was not instantiated from a `Board`!")
+        return self._board

--- a/tbot/machine/board/linux.py
+++ b/tbot/machine/board/linux.py
@@ -129,7 +129,7 @@ class LinuxBootLogin(machine.Initializer, LinuxBoot):
 Self = typing.TypeVar("Self", bound="LinuxUbootConnector")
 
 
-class LinuxUbootConnector(connector.Connector, LinuxBootLogin):
+class LinuxUbootConnector(connector.Connector, LinuxBootLogin, board.BoardMachineBase):
     """
     Connector for booting Linux from U-Boot.
 
@@ -212,3 +212,13 @@ class LinuxUbootConnector(connector.Connector, LinuxBootLogin):
     def clone(self: Self) -> Self:
         """This machine cannot be cloned."""
         raise NotImplementedError("can't clone Linux_U-Boot Machine")
+
+    @property
+    def board(self) -> board.Board:
+        if isinstance(self._b, board.Board):
+            return self._b
+        elif isinstance(self._b, board.UBootShell):
+            try:
+                return getattr(self._b, "board")  # type: ignore
+            except AttributeError:
+                raise Exception("U-Boot machine does not reference a board machine!")


### PR DESCRIPTION
Add a new protocol for all machines which were "derived" from a `board.Board` at some point.  These should all implement the `BoardMachineBase` protocol which demands a `.board` property for accessing the original board.

This is useful because the `board.Board` machine might be used to define some parameters for this specific physical hardware, like an IP address. A `BoardUBoot` or `BoardLinux` machine would then want to be generic over these parameters.  To illustrate:

```python
class MyBoard(..., board.Board):
    ip_address = "1.2.3.4"

@tbot.testcase
def foo_test():
    with tbot.ctx.request(tbot.role.BoardUBoot) as ub:
        ip_address = ub.board.ip_address

    with tbot.ctx.request(tbot.role.BoardLinux) as lnx:
        ip_address = lnx.board.ip_address
```

One could now define different configs with different settings while using the same `BoardUBoot` and `BoardLinux` implementations with all of them.