### PR TITLE
channel: Implement new escape sequence

### DIFF
--- a/tbot/machine/board/uboot.py
+++ b/tbot/machine/board/uboot.py
@@ -380,9 +380,7 @@ class UBootShell(shell.Shell, UbootStartup):
         can interactively run commands.  This method is used by the
         ``interactive_uboot`` testcase.
         """
-        tbot.log.message(
-            f"Entering interactive shell ({tbot.log.c('CTRL+D to exit').bold}) ..."
-        )
+        tbot.log.message(f"Entering interactive shell...")
 
         # It is important to send a space before the newline.  Otherwise U-Boot
         # will reexecute the last command which we definitely do not want here.

--- a/tbot/machine/linux/ash.py
+++ b/tbot/machine/linux/ash.py
@@ -268,6 +268,11 @@ class Ash(linux_shell.LinuxShell):
 
         try:
             self.ch.sendline("exit")
-            self.ch.read_until_prompt(timeout=0.5)
+            try:
+                self.ch.read_until_prompt(timeout=0.5)
+            except TimeoutError:
+                # we might still be in the inner shell so let's try exiting again
+                self.ch.sendline("exit")
+                self.ch.read_until_prompt(timeout=0.5)
         except TimeoutError:
             raise Exception("Failed to reacquire shell after interactive session!")

--- a/tbot/machine/linux/bash.py
+++ b/tbot/machine/linux/bash.py
@@ -276,6 +276,11 @@ class Bash(linux_shell.LinuxShell):
 
         try:
             self.ch.sendline("exit")
-            self.ch.read_until_prompt(timeout=0.5)
+            try:
+                self.ch.read_until_prompt(timeout=0.5)
+            except TimeoutError:
+                # we might still be in the inner shell so let's try exiting again
+                self.ch.sendline("exit")
+                self.ch.read_until_prompt(timeout=0.5)
         except TimeoutError:
             raise Exception("Failed to reacquire shell after interactive session!")

--- a/tbot/machine/shell.py
+++ b/tbot/machine/shell.py
@@ -108,7 +108,5 @@ class RawShell(machine.Machine):
         Connect tbot's stdio to this machine's channel.  This will allow
         interactive access to the machine.
         """
-        tbot.log.message(
-            f"Entering interactive shell ({tbot.log.c('CTRL+D to exit').bold}) ..."
-        )
+        tbot.log.message(f"Entering interactive shell...")
         self.ch.attach_interactive()

--- a/tbot_contrib/gdb.py
+++ b/tbot_contrib/gdb.py
@@ -103,7 +103,7 @@ class GDBShell(shell.Shell):
         tbot.log.message(
             f"Entering interactive GDB shell ({tbot.log.c('CTRL+D to exit').bold}) ..."
         )
-        self.ch.attach_interactive()
+        self.ch.attach_interactive(ctrld_exit=True)
 
         self.ch.sendcontrol("C")
         self.ch.read_until_prompt("(gdb) ")


### PR DESCRIPTION
Let's follow systemd and use "`CTRL-]` three times within 1 second" as the universal escape sequence in tbot.  There are a number of reasons for this:

1. The old (undocumented) `~.` would conflict with ssh sessions which means you need to escape the escape sequence (= `~~.`) when trying to exit a tbot interactive session inside an ssh session.
2. Any key-sequence made up of commonly used characters is bound to conflict _somewhere_.  `CTRL-]` will most likely never show up in actual interaction and even less so as three consecutive presses.

`Channel.attach_interactive()` will now also print out a message instructing about this escape sequence.  This should make sure nobody will ever get stuck inside an interactive session again.

The old "`CTRL-D` to exit" behavior can be re-activated for specific usecases using a new parameter.