### PR TITLE
Properly detect when remote end closes channel while tbot is reading

### DIFF
--- a/selftest/tests/test_channel.py
+++ b/selftest/tests/test_channel.py
@@ -8,15 +8,16 @@ from tbot.machine import board, channel, connector
 
 @pytest.fixture
 def ch() -> Iterator[channel.Channel]:
-    with channel.SubprocessChannel() as ch:
-        ch.read()
+    with tbot.log.with_verbosity(tbot.log.Verbosity.CHANNEL):
+        with channel.SubprocessChannel() as ch:
+            ch.read()
 
-        # We must ensure that nothing enters the history from the commands sent
-        # in the following tests.
-        ch.sendline("unset HISTFILE", read_back=True)
-        ch.read()
+            # We must ensure that nothing enters the history from the commands sent
+            # in the following tests.
+            ch.sendline("unset HISTFILE", read_back=True)
+            ch.read()
 
-        yield ch
+            yield ch
 
 
 def test_simple_command(ch: channel.Channel) -> None:

--- a/selftest/tests/test_channel.py
+++ b/selftest/tests/test_channel.py
@@ -103,6 +103,12 @@ def test_taking(ch: channel.Channel) -> None:
         ch.sendline("echo Illegal")
 
 
+def test_termination(ch: channel.Channel) -> None:
+    ch.sendline("exit")
+    with pytest.raises(channel.ChannelClosedException):
+        ch.read_until_timeout(5)
+
+
 def test_nullchannel_machine() -> None:
     """
     Ensure that we can instanciate a machine with a null channel properly.

--- a/tbot/machine/channel/channel.py
+++ b/tbot/machine/channel/channel.py
@@ -560,7 +560,8 @@ class Channel(typing.ContextManager):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
-        self.close()
+        if not self.closed:
+            self.close()
 
     # }}}
 


### PR DESCRIPTION
This PR should fix tbot hanging indefinitely when the remote end closes the channel while tbot is reading from it.  See commit messages for more details.

Fixes: #73