### PR TITLE
Move copy() into linux module and add a utils.copy_to_dir() helper to contrib

### DIFF
--- a/Documentation/contrib/utils.rst
+++ b/Documentation/contrib/utils.rst
@@ -7,4 +7,5 @@ Various testcases.
 .. autofunction:: tbot_contrib.utils.ensure_sd_unit
 .. autofunction:: tbot_contrib.utils.find_ip_address
 .. autofunction:: tbot_contrib.utils.hashcmp
+.. autofunction:: tbot_contrib.utils.copy_to_dir
 .. autofunction:: tbot_contrib.utils.strip_ansi_escapes

--- a/Documentation/modules/machine_linux.rst
+++ b/Documentation/modules/machine_linux.rst
@@ -237,6 +237,10 @@ Workdir
    .. automethod:: tbot.machine.linux.Workdir.xdg_data
    .. automethod:: tbot.machine.linux.Workdir.xdg_runtime
 
+``copy()``
+~~~~~~~~~~
+.. autofunction:: tbot.machine.linux.copy
+
 Lab-Host
 --------
 .. autoclass:: tbot.machine.linux.Lab

--- a/selftest/tests/test_copy.py
+++ b/selftest/tests/test_copy.py
@@ -1,0 +1,54 @@
+import pytest
+import testmachines
+from conftest import AnyLinuxShell
+
+import tbot
+from tbot.machine import linux
+
+
+def test_local_copy(any_linux_shell: AnyLinuxShell) -> None:
+    h: linux.LinuxShell
+    with any_linux_shell() as h:
+        testdir = h.workdir / "copy-tests"
+        h.exec0("rm", "-rf", testdir)
+        h.exec0("mkdir", testdir)
+
+        src = testdir / "source.txt"
+        dest = testdir / "destination.txt"
+
+        src.write_text("Hello linux.copy()!\n")
+        linux.copy(src, dest)
+
+        content = dest.read_text()
+        assert content == "Hello linux.copy()!\n"
+
+
+@pytest.mark.parametrize("direction", ["to", "from"])  # type: ignore
+def test_ssh_copy(direction: str, tbot_context: tbot.Context) -> None:
+    with tbot_context() as cx:
+        ssh = cx.request(testmachines.MocksshClient)
+        if not ssh.has_sftp:
+            pytest.skip("SFTP missing on server.")
+        testdir_ssh = ssh.workdir / "ssh-copy-tests2"
+        ssh.exec0("rm", "-rf", testdir_ssh)
+        ssh.exec0("mkdir", testdir_ssh)
+        file_ssh = testdir_ssh / "file.txt"
+
+        lo = cx.request(testmachines.Localhost)
+        testdir_lo = lo.workdir / "ssh-copy-tests1"
+        lo.exec0("rm", "-rf", testdir_lo)
+        lo.exec0("mkdir", testdir_lo)
+        file_lo = testdir_lo / "file.txt"
+
+        if direction == "to":
+            src, dest = file_lo, file_ssh
+        elif direction == "from":
+            src, dest = file_ssh, file_lo
+        else:
+            raise Exception(f"unknown direction {direction!r}")
+
+        expected = "Moin\n\nThis is a remote copy test!\n"
+        src.write_text(expected)
+        linux.copy(src, dest)
+        content = dest.read_text()
+        assert content == expected

--- a/tbot/machine/linux/__init__.py
+++ b/tbot/machine/linux/__init__.py
@@ -42,6 +42,7 @@ from .build import Builder
 from .lab import Lab
 from .util import RunCommandProxy, CommandEndedException
 from . import auth
+from .copy import copy
 
 __all__ = (
     "Ash",
@@ -68,6 +69,7 @@ __all__ = (
     "Workdir",
     "RunCommandProxy",
     "CommandEndedException",
+    "copy",
 )
 
 

--- a/tbot/machine/linux/copy.py
+++ b/tbot/machine/linux/copy.py
@@ -1,0 +1,166 @@
+import typing
+
+from tbot.machine import connector, linux
+from tbot.machine.linux import auth
+
+H1 = typing.TypeVar("H1", bound=linux.LinuxShell)
+H2 = typing.TypeVar("H2", bound=linux.LinuxShell)
+
+
+def _scp_copy(
+    *,
+    local_path: linux.Path[H1],
+    remote_path: linux.Path[H2],
+    copy_to_remote: bool,
+    username: str,
+    hostname: str,
+    ignore_hostkey: bool,
+    port: int,
+    ssh_config: typing.List[str],
+    authenticator: auth.Authenticator,
+) -> None:
+    local_host = local_path.host
+
+    hk_disable = ["-o", "StrictHostKeyChecking=no"] if ignore_hostkey else []
+
+    scp_command = [
+        "scp",
+        *["-P", str(port)],
+        *hk_disable,
+        *[arg for opt in ssh_config for arg in ["-o", opt]],
+    ]
+
+    if isinstance(authenticator, auth.NoneAuthenticator):
+        scp_command += ["-o", "BatchMode=yes"]
+    elif isinstance(authenticator, auth.PrivateKeyAuthenticator):
+        scp_command += [
+            "-o",
+            "BatchMode=yes",
+            "-i",
+            authenticator.get_key_for_host(local_host),
+        ]
+    elif isinstance(authenticator, auth.PasswordAuthenticator):
+        scp_command = ["sshpass", "-p", authenticator.password] + scp_command
+    else:
+        if typing.TYPE_CHECKING:
+            authenticator._undefined_marker
+        raise ValueError("Unknown authenticator {authenticator!r}")
+
+    if copy_to_remote:
+        local_host.exec0(
+            *scp_command,
+            local_path,
+            f"{username}@{hostname}:{remote_path.at_host(remote_path.host)}",
+        )
+    else:
+        local_host.exec0(
+            *scp_command,
+            f"{username}@{hostname}:{remote_path.at_host(remote_path.host)}",
+            local_path,
+        )
+
+
+def copy(p1: linux.Path[H1], p2: linux.Path[H2]) -> None:
+    """
+    Copy a file, possibly from one host to another.
+
+    The following transfers are currently supported:
+
+    * ``H`` 🢥 ``H`` (transfer without changing host)
+    * **lab-host** 🢥 **ssh-machine** (:py:class:`~tbot.machine.connector.SSHConnector`, using ``scp``)
+    * **ssh-machine** 🢥 **lab-host** (Using ``scp``)
+    * **local-host** 🢥 **paramiko-host** (:py:class:`~tbot.machine.connector.ParamikoConnector`, using ``scp``)
+    * **local-host** 🢥 **ssh-machine** (:py:class:`~tbot.machine.connector.SSHConnector`, using ``scp``)
+    * **paramiko-host**/**ssh-machine** 🢥 **local-host** (Using ``scp``)
+
+    The following transfers are **not** supported:
+
+    * **ssh-machine** 🢥 **ssh-machine** (There is no guarantee that two remote hosts can
+      connect to each other.  If you need this, transfer to the lab-host first
+      and then to the other remote)
+    * **lab-host** 🢥 **board-machine** (Transfers over serial are not (yet) implemented.
+      To 'upload' files, connect to your target via ssh or use a tftp download)
+
+    :param linux.Path p1: Exisiting path to be copied
+    :param linux.Path p2: Target where ``p1`` should be copied
+
+    .. note::
+
+        You can combine this function with :py:func:`tbot_contrib.utils.hashcmp`
+        to only copy a file when the hashsums of source and destination
+        mismatch:
+
+        .. code-block:: python
+
+            from tbot_contrib import utils
+            from tbot.tc import shell
+
+            ...
+            if not utils.hashcmp(path_a, path_b)
+                shell.copy(path_a, path_b)
+    """
+    if isinstance(p1.host, p2.host.__class__) or isinstance(p2.host, p1.host.__class__):
+        # Both paths are on the same host
+        p2_w1 = linux.Path(p1.host, p2)
+        p1.host.exec0("cp", p1, p2_w1)
+        return
+    elif isinstance(p1.host, connector.SSHConnector) and p1.host.host is p2.host:
+        # Copy from an SSH machine
+        _scp_copy(
+            local_path=p2,
+            remote_path=p1,
+            copy_to_remote=False,
+            username=p1.host.username,
+            hostname=p1.host.hostname,
+            ignore_hostkey=p1.host.ignore_hostkey,
+            port=p1.host.port,
+            ssh_config=p1.host.ssh_config,
+            authenticator=p1.host.authenticator,
+        )
+    elif isinstance(p2.host, connector.SSHConnector) and p2.host.host is p1.host:
+        # Copy to an SSH machine
+        _scp_copy(
+            local_path=p1,
+            remote_path=p2,
+            copy_to_remote=True,
+            username=p2.host.username,
+            hostname=p2.host.hostname,
+            ignore_hostkey=p2.host.ignore_hostkey,
+            port=p2.host.port,
+            ssh_config=p2.host.ssh_config,
+            authenticator=p2.host.authenticator,
+        )
+    elif isinstance(p1.host, connector.SubprocessConnector) and (
+        isinstance(p2.host, connector.ParamikoConnector)
+        or isinstance(p2.host, connector.SSHConnector)
+    ):
+        # Copy from local to ssh labhost
+        _scp_copy(
+            local_path=p1,
+            remote_path=p2,
+            copy_to_remote=True,
+            username=p2.host.username,
+            hostname=p2.host.hostname,
+            ignore_hostkey=p2.host.ignore_hostkey,
+            port=p2.host.port,
+            ssh_config=getattr(p2.host, "ssh_config", []),
+            authenticator=p2.host.authenticator,
+        )
+    elif isinstance(p2.host, connector.SubprocessConnector) and (
+        isinstance(p1.host, connector.ParamikoConnector)
+        or isinstance(p1.host, connector.SSHConnector)
+    ):
+        # Copy to local from ssh labhost
+        _scp_copy(
+            local_path=p2,
+            remote_path=p1,
+            copy_to_remote=False,
+            username=p1.host.username,
+            hostname=p1.host.hostname,
+            ignore_hostkey=p1.host.ignore_hostkey,
+            port=p1.host.port,
+            ssh_config=getattr(p2.host, "ssh_config", []),
+            authenticator=p1.host.authenticator,
+        )
+    else:
+        raise NotImplementedError(f"Can't copy from {p1.host} to {p2.host}!")

--- a/tbot/tc/shell.py
+++ b/tbot/tc/shell.py
@@ -15,67 +15,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import typing
-import tbot
-from tbot.machine import linux, connector
-from tbot.machine.linux import auth
 
-__all__ = ("copy",)
+import tbot
+from tbot.machine import linux
+
+__all__ = ("check_for_tool", "copy")
 
 H1 = typing.TypeVar("H1", bound=linux.LinuxShell)
 H2 = typing.TypeVar("H2", bound=linux.LinuxShell)
-
-
-def _scp_copy(
-    *,
-    local_path: linux.Path[H1],
-    remote_path: linux.Path[H2],
-    copy_to_remote: bool,
-    username: str,
-    hostname: str,
-    ignore_hostkey: bool,
-    port: int,
-    ssh_config: typing.List[str],
-    authenticator: auth.Authenticator,
-) -> None:
-    local_host = local_path.host
-
-    hk_disable = ["-o", "StrictHostKeyChecking=no"] if ignore_hostkey else []
-
-    scp_command = [
-        "scp",
-        *["-P", str(port)],
-        *hk_disable,
-        *[arg for opt in ssh_config for arg in ["-o", opt]],
-    ]
-
-    if isinstance(authenticator, auth.NoneAuthenticator):
-        scp_command += ["-o", "BatchMode=yes"]
-    elif isinstance(authenticator, auth.PrivateKeyAuthenticator):
-        scp_command += [
-            "-o",
-            "BatchMode=yes",
-            "-i",
-            authenticator.get_key_for_host(local_host),
-        ]
-    elif isinstance(authenticator, auth.PasswordAuthenticator):
-        scp_command = ["sshpass", "-p", authenticator.password] + scp_command
-    else:
-        if typing.TYPE_CHECKING:
-            authenticator._undefined_marker
-        raise ValueError("Unknown authenticator {authenticator!r}")
-
-    if copy_to_remote:
-        local_host.exec0(
-            *scp_command,
-            local_path,
-            f"{username}@{hostname}:{remote_path.at_host(remote_path.host)}",
-        )
-    else:
-        local_host.exec0(
-            *scp_command,
-            f"{username}@{hostname}:{remote_path.at_host(remote_path.host)}",
-            local_path,
-        )
 
 
 @tbot.testcase
@@ -83,106 +30,13 @@ def copy(p1: linux.Path[H1], p2: linux.Path[H2]) -> None:
     """
     Copy a file, possibly from one host to another.
 
-    The following transfers are currently supported:
+    .. versionchanged:: UNRELEASED
 
-    * ``H`` 🢥 ``H`` (transfer without changing host)
-    * **lab-host** 🢥 **ssh-machine** (:py:class:`~tbot.machine.connector.SSHConnector`, using ``scp``)
-    * **ssh-machine** 🢥 **lab-host** (Using ``scp``)
-    * **local-host** 🢥 **paramiko-host** (:py:class:`~tbot.machine.connector.ParamikoConnector`, using ``scp``)
-    * **local-host** 🢥 **ssh-machine** (:py:class:`~tbot.machine.connector.SSHConnector`, using ``scp``)
-    * **paramiko-host**/**ssh-machine** 🢥 **local-host** (Using ``scp``)
-
-    The following transfers are **not** supported:
-
-    * **ssh-machine** 🢥 **ssh-machine** (There is no guarantee that two remote hosts can
-      connect to each other.  If you need this, transfer to the lab-host first
-      and then to the other remote)
-    * **lab-host** 🢥 **board-machine** (Transfers over serial are not (yet) implemented.
-      To 'upload' files, connect to your target via ssh or use a tftp download)
-
-    :param linux.Path p1: Exisiting path to be copied
-    :param linux.Path p2: Target where ``p1`` should be copied
-
-    .. note::
-
-        You can combine this function with :py:func:`tbot_contrib.utils.hashcmp`
-        to only copy a file when the hashsums of source and destination
-        mismatch:
-
-        .. code-block:: python
-
-            from tbot_contrib import utils
-            from tbot.tc import shell
-
-            ...
-            if not utils.hashcmp(path_a, path_b)
-                shell.copy(path_a, path_b)
+        This function has been moved to :py:func:`tbot.machine.linux.copy`.
+        Please read its documentation for more details.  The old name here is a
+        compatibility alias.
     """
-    if isinstance(p1.host, p2.host.__class__) or isinstance(p2.host, p1.host.__class__):
-        # Both paths are on the same host
-        p2_w1 = linux.Path(p1.host, p2)
-        p1.host.exec0("cp", p1, p2_w1)
-        return
-    elif isinstance(p1.host, connector.SSHConnector) and p1.host.host is p2.host:
-        # Copy from an SSH machine
-        _scp_copy(
-            local_path=p2,
-            remote_path=p1,
-            copy_to_remote=False,
-            username=p1.host.username,
-            hostname=p1.host.hostname,
-            ignore_hostkey=p1.host.ignore_hostkey,
-            port=p1.host.port,
-            ssh_config=p1.host.ssh_config,
-            authenticator=p1.host.authenticator,
-        )
-    elif isinstance(p2.host, connector.SSHConnector) and p2.host.host is p1.host:
-        # Copy to an SSH machine
-        _scp_copy(
-            local_path=p1,
-            remote_path=p2,
-            copy_to_remote=True,
-            username=p2.host.username,
-            hostname=p2.host.hostname,
-            ignore_hostkey=p2.host.ignore_hostkey,
-            port=p2.host.port,
-            ssh_config=p2.host.ssh_config,
-            authenticator=p2.host.authenticator,
-        )
-    elif isinstance(p1.host, connector.SubprocessConnector) and (
-        isinstance(p2.host, connector.ParamikoConnector)
-        or isinstance(p2.host, connector.SSHConnector)
-    ):
-        # Copy from local to ssh labhost
-        _scp_copy(
-            local_path=p1,
-            remote_path=p2,
-            copy_to_remote=True,
-            username=p2.host.username,
-            hostname=p2.host.hostname,
-            ignore_hostkey=p2.host.ignore_hostkey,
-            port=p2.host.port,
-            ssh_config=getattr(p2.host, "ssh_config", []),
-            authenticator=p2.host.authenticator,
-        )
-    elif isinstance(p2.host, connector.SubprocessConnector) and (
-        isinstance(p1.host, connector.ParamikoConnector)
-        or isinstance(p1.host, connector.SSHConnector)
-    ):
-        # Copy to local from ssh labhost
-        _scp_copy(
-            local_path=p2,
-            remote_path=p1,
-            copy_to_remote=False,
-            username=p1.host.username,
-            hostname=p1.host.hostname,
-            ignore_hostkey=p1.host.ignore_hostkey,
-            port=p1.host.port,
-            ssh_config=getattr(p2.host, "ssh_config", []),
-            authenticator=p1.host.authenticator,
-        )
-    else:
-        raise NotImplementedError(f"Can't copy from {p1.host} to {p2.host}!")
+    return linux.copy(p1, p2)
 
 
 _TOOL_CACHE: typing.Dict[linux.LinuxShell, typing.Dict[str, bool]] = {}


### PR DESCRIPTION
The main purpose of the PR is adding the `copy_to_dir()` helper in `tbot_contrib.utils`.  This helper can be used to copy one or many files to a directory.  The copies will each have the same name as the respective source file.  `copy_to_dir()` will return the path(s) to the copies.

Under the hood, it uses `copy()` which was moved from `tc.shell` to `machine.linux` (although the old name still exists for compat).  This means that `copy_to_dir()` also works across SSH connections.