### PR TITLE
linux.util: Fix wait_for_shell hang

### DIFF
--- a/tbot/machine/linux/util.py
+++ b/tbot/machine/linux/util.py
@@ -21,17 +21,14 @@ M = typing.TypeVar("M", bound="linux.LinuxShell")
 
 
 def wait_for_shell(ch: channel.Channel) -> None:
-    # Repeatedly sends `echo TBOT''LOGIN\r`.  At some point, the shell
-    # interprets this command and prints out `TBOTLOGIN` because of the
-    # quotation-marks being removed.  Once we detect this, this function
-    # can return, knowing the shell is now running on the other end.
-    #
-    # Credit to Pavel for this idea!
+    # Repeatedly attempt to run the expression.  At some point, the shell
+    # evaluates this expression and prints out `42`.  Once we detect this,
+    # this function can return, knowing the shell is now running on the other end.
     timeout = 0.2
     while True:
-        ch.sendline("echo TBOT''LOGIN")
+        ch.sendline("expr 41 + 1")
         try:
-            ch.expect("TBOTLOGIN", timeout=timeout)
+            ch.expect("42", timeout=timeout)
             break
         except TimeoutError:
             # Increase the timeout after the first try because the remote might


### PR DESCRIPTION
This change modifies tbot's wait_for_shell() to evaluate simple math instead of the existing echo TBOT''LOGIN. If a portion of the previously used echo command is dropped (including one single quote character but not both), then the shell interprets the command to be a multiline command. All subsequent retries of the echo command are then interpreted as part of the command, instead of new commands, and this loop essentially continues forever.

Using expr 41 + 1 and expecting 42 achieves the same objective of determining if the shell is ready but is protected against dropped characters resulting in an infinite loop.