### PR TITLE
connector: ssh: Fix connecting via lab-host for real

### DIFF
--- a/tbot/machine/connector/ssh.py
+++ b/tbot/machine/connector/ssh.py
@@ -157,7 +157,7 @@ class SSHConnector(connector.Connector):
     ) -> typing.Iterator[Self]:
         with contextlib.ExitStack() as cx:
             lh = None
-            if isinstance(cls, ctx.get_machine_class(tbot.role.LabHost)):
+            if not issubclass(cls, ctx.get_machine_class(tbot.role.LabHost)):
                 lh = cx.enter_context(ctx.request(tbot.role.LabHost))
             m = cx.enter_context(cls(lh))  # type: ignore
             yield typing.cast(Self, m)


### PR DESCRIPTION
The previous attempt at fixing the special-casing of lab-host vs. local-host based connections in commit f9f2fe8a2512 ("connector: ssh: Fix contexts breaking ssh lab-host usecase") actually never worked as intended.

Fix it by using the proper subclass check.

Fixes: f9f2fe8a2512 ("connector: ssh: Fix contexts breaking ssh lab-host usecase")