### PR TITLE
board.linux: Add pasword prompt variable

### DIFF
--- a/tbot/machine/board/linux.py
+++ b/tbot/machine/board/linux.py
@@ -87,6 +87,9 @@ class LinuxBootLogin(machine.Initializer, LinuxBoot):
     log-messages during the first few seconds after boot.
     """
 
+    password_prompt: channel.channel.ConvenientSearchString = "assword: "
+    """Prompt that indicates tbot should send the password."""
+
     boot_timeout: typing.Optional[float] = None
     """
     Maximum time for Linux to reach the login prompt.
@@ -174,7 +177,9 @@ class LinuxBootLogin(machine.Initializer, LinuxBoot):
                         timeout = min(timeout, self.no_password_timeout)
 
                 try:
-                    self.ch.read_until_prompt(prompt="assword: ", timeout=timeout)
+                    self.ch.read_until_prompt(
+                        prompt=self.password_prompt, timeout=timeout
+                    )
                 except TimeoutError:
                     # Call _timeout_remaining() to abort if the boot-timeout was reached
                     self._timeout_remaining()


### PR DESCRIPTION
The expected value for password prompt was hardcoded ("assword: ") which results in an unability to login when the language is not set to English. This commit adds a new variable which is by default set to the previously hardcoded string, but allows the user to overwrite it on demand.