### PR TITLE
fix stalled subprocess close

### DIFF
--- a/tbot/machine/channel/subprocess.py
+++ b/tbot/machine/channel/subprocess.py
@@ -104,7 +104,11 @@ class SubprocessChannelIO(channel.ChannelIO):
         self.p.terminate()
         os.close(self.pty_slave)
         os.close(self.pty_master)
-        self.p.wait()
+        try:
+            outs, errs = self.p.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.p.kill()
+            outs, errs = self.p.communicate()
 
         # Wait for all processes in the session to end.  Most of the time
         # this will return immediately, but in some cases (eg. a serial session

--- a/tbot/machine/channel/subprocess.py
+++ b/tbot/machine/channel/subprocess.py
@@ -105,10 +105,10 @@ class SubprocessChannelIO(channel.ChannelIO):
         os.close(self.pty_slave)
         os.close(self.pty_master)
         try:
-            outs, errs = self.p.communicate(timeout=10)
+            self.p.communicate(timeout=10)
         except subprocess.TimeoutExpired:
             self.p.kill()
-            outs, errs = self.p.communicate()
+            self.p.communicate()
 
         # Wait for all processes in the session to end.  Most of the time
         # this will return immediately, but in some cases (eg. a serial session


### PR DESCRIPTION
This fix is possibly related to the problem described in #94 by @yanivy-nr.


It happens from time to time that subprocess close() stalls forever. I guess the reason is a raise conditions when terminating the process and closing the piped streams.

A note in Python's [subprocess documentation](https://docs.python.org/3/library/subprocess.html) suggests to use following code snipped to properly terminate/kill a subprocess:

    proc = subprocess.Popen(...)
    try:
        outs, errs = proc.communicate(timeout=15)
    except TimeoutExpired:
        proc.kill()
        outs, errs = proc.communicate()
