### PR TITLE
machine: u-boot: Add a hacky workaround for the crc32 command

### DIFF
--- a/selftest/testmachines.py
+++ b/selftest/testmachines.py
@@ -272,6 +272,11 @@ function setenv() {
     shift
     eval "$var=\\"$*\\""
 }
+function crc32() {
+    printf "crc32 for %s ... %s ==> " "$1" "$1"
+    sleep 0.2
+    echo "deadb33f"
+}
 function boot() {
     echo "Pretending to boot Linux..."
     echo ""

--- a/selftest/tests/test_board.py
+++ b/selftest/tests/test_board.py
@@ -59,6 +59,14 @@ def test_uboot_simple_control(tbot_context: tbot.Context) -> None:
         assert out == "FOO"
 
 
+def test_uboot_crc32_workaround(tbot_context: tbot.Context) -> None:
+    with tbot_context.request(testmachines.MockhwBoardUBoot) as ub:
+        if ub.prompt != "=> ":
+            pytest.skip("Wrong U-Boot prompt for crc32 workaround test.")
+        ub.exec0("crc32", "0x10000008", "0x42")
+        assert ub.exec0("echo", "Hello World") == "Hello World\n"
+
+
 def test_linux_boot(tbot_context: tbot.Context) -> None:
     with tbot_context.request(testmachines.MockhwBoardLinux) as lnx:
         out = lnx.exec0("echo", "Hello World")


### PR DESCRIPTION
The `crc32` command in U-Boot unfortunately prints the character sequence `=> ` as part of its output.  This character sequence is an often used U-Boot prompt, which means tbot's prompt-searching code gets confused by `crc32` output.

Unfortunately, there is no real solution to this.  At least none that works universally.  So to at least ease the pain a bit for people running into this, attempt automatically applying a workaround for this specific situation.

Closes #111.