### PR TITLE
machine: linux: Add sanity check for shell interaction

### DIFF
--- a/tbot/error.py
+++ b/tbot/error.py
@@ -169,6 +169,31 @@ class ChannelClosedError(MachineError):
     """
 
 
+class UncleanShellError(MachineError):
+    """
+    While trying to prepare the remote shell, tbot detected unexpected behavior.
+
+    This error means that the shell responded with unexpected output during
+    setup.  tbot cannot proceed to interact, as it cannot be certain about the
+    state of the remote shell.
+
+    If you encounter this error, enable verbose channel logging to see what
+    unexpected output was received.  You need to ensure that the remote system
+    does not send this additional output.
+
+    .. versionadded:: UNRELEASED
+    """
+
+    def __init__(
+        self,
+        host: "machine.Machine",
+    ) -> None:
+        self.host = host
+        super().__init__(
+            f"detected unclean shell for {host.name!r}, cannot interact safely"
+        )
+
+
 class InvalidRetcodeError(MachineError):
     """
     While trying to fetch the return code of a command, unexpected output was received.

--- a/tbot/machine/linux/ash.py
+++ b/tbot/machine/linux/ash.py
@@ -92,6 +92,10 @@ class Ash(linux_shell.LinuxShell):
             self.ch.sendline("PS2=''")
             self.ch.read_until_prompt()
 
+            # Do a sanity check to assert that shell interaction is working
+            # exactly as expected
+            util.shell_sanity_check(self)
+
             yield None
         finally:
             pass

--- a/tbot/machine/linux/bash.py
+++ b/tbot/machine/linux/bash.py
@@ -99,6 +99,10 @@ class Bash(linux_shell.LinuxShell):
             self.ch.sendline(f"stty rows {termsize.lines}")
             self.ch.read_until_prompt()
 
+            # Do a sanity check to assert that shell interaction is working
+            # exactly as expected
+            util.shell_sanity_check(self)
+
             yield None
         finally:
             pass

--- a/tbot/machine/linux/util.py
+++ b/tbot/machine/linux/util.py
@@ -72,6 +72,13 @@ def posix_environment(
         return mach.exec0("echo", linux.Raw(f'" ${{{var}}}"'))[1:-1]
 
 
+def shell_sanity_check(mach: M) -> None:
+    mach.ch.sendline("echo TBOT-SANITY-CHECK", read_back=True)
+    output = mach.ch.read_until_prompt()
+    if output != "TBOT-SANITY-CHECK\n":
+        raise tbot.error.UncleanShellError(mach)
+
+
 # Type alias for the command context function/generator.  This function needs
 # to be provided by the shell and contains the actual implementation of
 # spawning an interactive command (and cleaning up / checking the return code


### PR DESCRIPTION
Add a sanity check that ensures the shell on the remote end is really in the state we expect it to be in before we start interacting with it.

This check should uncover the following kinds of errors early:

 - Heavy amounts of output clobbering from some source
 - tbot tracking the wrong prompt (offset error)
 - fancy shell configuration that tbot wasn't able to disable

Previously, such errors would only surface later, when trying to run commands.  The error messages were quite confusing and didn't immediately point to the root cause.  This sanity check should hopefully make debugging these issues much easier.