### PR TITLE
machine.channel Fix hanging on read_until_prompt.

### DIFF
--- a/tbot/machine/channel/channel.py
+++ b/tbot/machine/channel/channel.py
@@ -914,9 +914,10 @@ class Channel(typing.ContextManager):
                 buf += new
 
                 if isinstance(self.prompt, bytes):
-                    if buf.endswith(self.prompt):
+                    index = buf.find(self.prompt)
+                    if index > -1:
                         return (
-                            buf[: -len(self.prompt)]
+                            buf[:index]
                             .decode("utf-8", errors="replace")
                             .replace("\r\n", "\n")
                             .replace("\n\r", "\n")


### PR DESCRIPTION
On some devices, logs may be printed just after the prompt. In such case prompt lands in the middle of a buffer, not at the end. This change is to avoid infinite hanging in such cases.