### PR TITLE
newbot: add a more general flag/parameter

### DIFF
--- a/Documentation/cli.rst
+++ b/Documentation/cli.rst
@@ -38,7 +38,8 @@ document here serves as a reference documentation.
      -h, --help            show this help message and exit
      -C WORKDIR            use WORKDIR as working directory instead of the current directory.
      -c CONFIG, --config CONFIG
-     -f FLAG               set a user defined flag to change testcase behaviour
+     -f FLAG[=VALUE]       set a user defined flag with or without a custom value to change
+                           testcase behaviour.
      -k, --keep-alive      keep machines alive for later tests to reacquire them
      -v                    increase the verbosity
      -q                    decrease the verbosity
@@ -79,16 +80,21 @@ testcases.  For example, a flag might be used to switch to booting from a
 different source.
 
 All flags passed to ``newbot`` with ``-f`` are added to the
-:py:data:`tbot.flags` set.  Config and testcases can then check for them like
+:py:data:`tbot.flags` set.  Config and testcases can then check for them and 
+use the stored value like
 this:
 
 .. code-block:: python
 
-   # Check if flag is present
+   # Check if flag is present and use value
    if "boot-nfs" in tbot.flags:
-       bootargs = "root=/dev/nfs nfsroot=...,tcp,v3"
+       bootargs = f"root=/dev/nfs nfsroot={tbot.flags["boot-nfs"]},tcp,v3"
    else:
        bootargs = "root=/dev/mmcblk0p1"
+
+   # Check if flag is present
+   if "no-console" in tbot.flags:
+       bootargs += " console=null"
 
    # Check if flag is absent
    if "silent-boot" not in tbot.flags:

--- a/tbot/__init__.py
+++ b/tbot/__init__.py
@@ -56,7 +56,7 @@ __all__ = (
     "role",
 )
 
-flags: typing.Set[str] = set()
+flags: typing.Dict[str, typing.Any] = dict()
 
 F_tc = typing.TypeVar("F_tc", bound=typing.Callable[..., typing.Any])
 

--- a/tbot/newbot.py
+++ b/tbot/newbot.py
@@ -235,7 +235,14 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     import tbot.log_event
 
     for flag in args.flags:
-        tbot.flags.add(flag)
+        if "=" in flag:
+            (flag_name, value) = flag.split("=", 1)
+        else:
+            flag_name = flag
+            value = True
+        tbot.flags[flag_name] = value
+
+    tbot.log.message(f"flags: {tbot.flags}")
 
     if args.json_log_stream:
         tbot.log.LOGFILE = open(args.json_log_stream, "w")


### PR DESCRIPTION
For some use cases it would be helpful when the flags can have some values attached.
    `newbot -c config.config1 --flag foo=bar tc.testcase`