### PR TITLE
Added support for legacy SCP protocol.

### DIFF
--- a/tbot/machine/connector/ssh.py
+++ b/tbot/machine/connector/ssh.py
@@ -66,6 +66,16 @@ class SSHConnector(connector.Connector):
         return False
 
     @property
+    def requires_legacy_scp(self) -> bool:
+        """
+        Use the legacy SCP protocol for file transfers instead of the SFTP protocol.
+
+        Forcing the use of the SCP protocol may be necessary for servers that do not
+        implement SFTP, for backwards compatibility.
+        """
+        return False
+
+    @property
     def use_multiplexing(self) -> bool:
         """
         Whether tbot should attempt to enable connection multiplexing.

--- a/tbot/machine/linux/copy.py
+++ b/tbot/machine/linux/copy.py
@@ -31,6 +31,10 @@ def _scp_copy(
         *[arg for opt in ssh_config for arg in ["-o", opt]],
     ]
 
+    use_legacy_protocol = getattr(remote_path.host, "requires_legacy_scp", False)
+    if use_legacy_protocol:
+        scp_command += ["-O"]
+
     if use_multiplexing:
         multiplexing_dir = local_host.workdir / ".ssh-multi"
         scp_command += ["-o", "ControlMaster=auto"]


### PR DESCRIPTION
Added option `use_legacy_protocol:bool` to `linux.copy` and `utils.copy_to_dir` to use the legacy SCP protocol for file transfers instead of the SFTP protocol.  Forcing the use of the SCP protocol may be necessary for servers that do not implement SFTP,  for backwards compatibility. In essence is to pass `-O` option to SCP command.