### PR TITLE
channel: Avoid deprecated sre_parse module

### DIFF
--- a/tbot/machine/channel/channel.py
+++ b/tbot/machine/channel/channel.py
@@ -193,7 +193,13 @@ class BoundedPattern:
     def __init__(self, pattern: typing.Pattern[bytes]) -> None:
         self.pattern = pattern
 
-        import sre_parse
+        try:
+            # Python >= 3.11 moved this module to `re._parser` and turned
+            # `sre_parse` into a deprecated compatibility shim around it.
+            from re import _parser as sre_parse  # type: ignore[attr-defined]
+        except ImportError:
+            # Python < 3.11 doesn't have `re._parser` yet.
+            import sre_parse
 
         parsed = sre_parse.parse(
             typing.cast(str, self.pattern.pattern), flags=self.pattern.flags


### PR DESCRIPTION
Fixes #125.

Since Python 3.11, importing `sre_parse` emits a `DeprecationWarning`:

```
path_to_tbot/tbot/machine/channel/channel.py:196: DeprecationWarning: module 'sre_parse' is deprecated
    import sre_parse
```

`sre_parse` was never public API; CPython 3.11 moved its implementation
to `re._parser` and turned `sre_parse` into a deprecated compatibility
shim around it. This uses `re._parser` when available and falls back
to `sre_parse` on Python < 3.11, where `re._parser` does not exist yet.

`re._parser` is private too, but it's the current, non-deprecated home
of this parsing logic, and there's no public `re` API that exposes the
regex match width `BoundedPattern` needs — so this is a "use the
current internal name" fix rather than a way to drop the dependency on
internals altogether.

## Testing

- `pre-commit`'s pinned `black`, `flake8`, and `mypy` all pass on the
  changed file.
- `selftest/tests/test_channel.py` passes identically before and after
  (14 passed), and confirms the warning is gone: running it against
  unmodified `master` reproduces the exact warning from the issue,
  while this branch is silent under `-W error::DeprecationWarning`.
- Manually verified `BoundedPattern` still computes the same widths and
  still rejects unbounded patterns (e.g. `a(b+)c`) with
  `UnboundedPatternError`, on Python 3.14.