### PR TITLE
path: Force-remove files in unlink()

### DIFF
--- a/selftest/tests/test_path.py
+++ b/selftest/tests/test_path.py
@@ -133,6 +133,21 @@ def test_regular_file(testdir_builder: "TestDir") -> None:
         assert not regular_file.is_file()
 
 
+def test_unlink_write_protected(testdir_builder: "TestDir") -> None:
+    with testdir_builder() as testdir:
+        write_protected_file = testdir / "a-write-protected-file"
+        testdir.host.exec0("touch", write_protected_file)
+        testdir.host.exec0("chmod", "0400", write_protected_file)
+        assert write_protected_file.exists()
+
+        # Even though the file itself is write-protected, unlink() should
+        # still succeed as long as the containing directory permits removal
+        # (matching the behavior of Python's pathlib).
+        write_protected_file.unlink()
+
+        assert not write_protected_file.exists()
+
+
 def test_directory(testdir_builder: "TestDir") -> None:
     with testdir_builder() as testdir:
         directory = testdir / "directory"

--- a/tbot/machine/linux/path.py
+++ b/tbot/machine/linux/path.py
@@ -564,7 +564,7 @@ class Path(typing.Generic[H]):
                 )
             return
 
-        self.host.exec0("rm", "-f", self)
+        self.host.exec0("rm", "-f", "--", self)
 
     def mkdir(self, parents: bool = False, exist_ok: bool = False) -> None:
         """

--- a/tbot/machine/linux/path.py
+++ b/tbot/machine/linux/path.py
@@ -564,7 +564,7 @@ class Path(typing.Generic[H]):
                 )
             return
 
-        self.host.exec0("rm", self)
+        self.host.exec0("rm", "-f", self)
 
     def mkdir(self, parents: bool = False, exist_ok: bool = False) -> None:
         """


### PR DESCRIPTION
Fixes #128.

`Path.unlink()` removes a file with a plain `rm`:

```python
self.host.exec0("rm", self)
```

If the file is write-protected (e.g. `-r--r--r--`) but the containing
directory still permits deletion, GNU `rm` asks an interactive
confirmation question before removing it:

```
rm: remove write-protected regular file '...'?
```

Since tbot's channel has no way to answer that question, `exec0()`
never sees a shell prompt again and hangs indefinitely instead of
raising an error.

`unlink()` already resolves existence/`missing_ok` itself before
running `rm`, so nothing is lost by making the actual removal
non-interactive as well, via `-f`.

## Testing

- `pre-commit`'s pinned `black`, `flake8`, and `mypy` all pass on the
  changed file.
- `selftest/tests/test_path.py` has the same pass/fail counts before
  and after this change (two pre-existing, unrelated failures in
  `test_rglob_error` reproduce identically on unmodified `master`).
- Reproduced the actual bug: unlinking a `chmod 400` file hangs
  (confirmed via timeout) on unmodified `master`, and completes cleanly
  on this branch.