### PR TITLE
linux: copy: Recognize any two SubprocessConnector machines as same-host

### DIFF
--- a/tbot/machine/linux/copy.py
+++ b/tbot/machine/linux/copy.py
@@ -115,9 +115,27 @@ def copy(p1: linux.Path[H1], p2: linux.Path[H2]) -> None:
 
     .. versionadded:: 0.10.2
     """
-    if isinstance(p1.host, p2.host.__class__) or isinstance(p2.host, p1.host.__class__):
-        # Both paths are on the same host
-        p2_w1 = linux.Path(p1.host, p2)
+    if (
+        isinstance(p1.host, p2.host.__class__)
+        or isinstance(p2.host, p1.host.__class__)
+        or (
+            isinstance(p1.host, connector.SubprocessConnector)
+            and isinstance(p2.host, connector.SubprocessConnector)
+        )
+    ):
+        # Both paths are on the same host.  Besides the case where one
+        # machine's class is a subclass of the other's, this is also true
+        # whenever both machines are `SubprocessConnector`-based: There is
+        # only one localhost, so any two such machines are guaranteed to
+        # share the same filesystem even if their classes are unrelated.
+        #
+        # `p2` is reinterpreted as a path on `p1.host` below.  This has to
+        # go through `_local_str()` rather than `Path(p1.host, p2)` because
+        # the latter additionally requires `p2.host == p1.host`, which is
+        # generally false here: `p1.host` and `p2.host` are two distinct
+        # machine instances (not clones of the same original), even though
+        # we've just established they share the same filesystem.
+        p2_w1 = linux.Path(p1.host, p2._local_str())
         p1.host.exec0("cp", p1, p2_w1)
         return
     elif isinstance(p1.host, connector.SSHConnector) and p1.host.host is p2.host:


### PR DESCRIPTION
Fixes #129.

`linux.copy()`'s same-host detection only matched when one machine's
class was a subclass of the other's:

```python
if isinstance(p1.host, p2.host.__class__) or isinstance(p2.host, p1.host.__class__):
```

If a project defines two separate machine classes that both connect
via `connector.SubprocessConnector` (i.e. both actually run on
localhost) but don't inherit from each other, `copy()` falls through
every SSH/Paramiko-specific branch and raises `NotImplementedError`,
even though both machines run on the same filesystem and a plain `cp`
would work. Fixed by also recognizing any two `SubprocessConnector`
instances as being on the same host, regardless of their exact class.

## A second bug found while testing

While testing this, a second, independent bug in the same code path
surfaced: even when the isinstance check above already matched (e.g.
literally the same class), the fast path still raised
`WrongHostError` for any two machine instances that aren't clones of
one another. This is because `p2_w1 = linux.Path(p1.host, p2)`
implicitly requires `p2.host == p1.host`, and `Machine.__eq__` only
considers clones of the same original equal — not just
"same/compatible class". So the same-host fast path only ever worked
when `p1.host` and `p2.host` were already the exact same object to
begin with, making the isinstance check mostly dead code in practice.

Fixed by reinterpreting `p2`'s raw path via `p2._local_str()` instead
of wrapping the `Path` object itself, since by the time we reach this
branch same-host compatibility has already been established by the
outer condition.

## Testing

- `pre-commit`'s pinned `black`, `flake8`, and `mypy` all pass on the
  changed file.
- Reproduced both bugs directly against unmodified `master`:
  - Two unrelated `SubprocessConnector`-based classes: `NotImplementedError`.
  - Two instances of the *same* class (not clones): `WrongHostError`.
  Both succeed on this branch.
- `selftest/` (excluding the subset that needs a real `sshd`, which
  this sandbox doesn't have) has identical pass/fail counts before and
  after this change: 5 failed / 104 passed on both `master` and this
  branch.